### PR TITLE
Tidy up logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ It wouldn't be possible without the work of the AHL Data Engineering Team includ
  * Drake Siard
  * [Slavi Marinov](https://github.com/slavi)
  * [Wilfred Hughes](https://github.com/wilfred)
+ * [Edward Easton](https://github.com/eeaston)
  * ... and many others ...
 
 Contributions welcome!

--- a/arctic/_compression.py
+++ b/arctic/_compression.py
@@ -1,6 +1,8 @@
 import lz4
 import os
-from .logging import logger
+import logging
+
+logger = logging.getLogger(__name__)
 
 try:
     from . import _compress as clz4

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -1,10 +1,10 @@
-from datetime import datetime
 from pandas import DataFrame
 from pandas.util.testing import assert_frame_equal
 from pymongo.errors import OperationFailure
 import string
+import logging
 
-from .logging import logger
+logger = logging.getLogger(__name__)
 
 
 def indent(s, num_spaces):
@@ -45,10 +45,10 @@ def enable_sharding(arctic, library_name, hashed=False):
 def enable_powerof2sizes(arctic, library_name):
     lib = arctic[library_name]._arctic_lib
     collection = lib.get_top_level_collection()
-    lib._db.command({"collMod" : collection.name, 'usePowerOf2Sizes': "true"})
+    lib._db.command({"collMod": collection.name, 'usePowerOf2Sizes': "true"})
     logger.info("usePowerOf2Sizes enabled for %s", collection.name)
 
     for coll in collection.database.collection_names():
         if coll.startswith("%s." % collection.name):
-            lib._db.command({"collMod" : coll, 'usePowerOf2Sizes': "true"})
+            lib._db.command({"collMod": coll, 'usePowerOf2Sizes': "true"})
             logger.info("usePowerOf2Sizes enabled for %s", coll)

--- a/arctic/auth.py
+++ b/arctic/auth.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
+import logging
 
-from .logging import logger
+logger = logging.getLogger(__name__)
+
 
 def authenticate(db, user, password):
     """
@@ -18,6 +20,7 @@ def authenticate(db, user, password):
 
 
 Credential = namedtuple("MongoCredentials", ['database', 'user', 'password'])
+
 
 def get_auth(host, app_name, database_name):
     """

--- a/arctic/date/_daterange.py
+++ b/arctic/date/_daterange.py
@@ -1,8 +1,5 @@
 import datetime
-from datetime import timedelta
-from dateutil.tz import tzlocal
 
-from ..logging import logger
 from ._generalslice import OPEN_OPEN, CLOSED_CLOSED, OPEN_CLOSED, CLOSED_OPEN, GeneralSlice
 from ._parse import parse
 

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -1,8 +1,6 @@
 import bisect
 import os
 import dateutil
-from decorator import decorator
-import time
 import tzlocal
 
 DEFAULT_TIME_ZONE_NAME = tzlocal.get_localzone().zone  # 'Europe/London'

--- a/arctic/date/_util.py
+++ b/arctic/date/_util.py
@@ -2,9 +2,8 @@ import calendar
 import datetime
 from datetime import timedelta
 
-from ..logging import logger
 from ._daterange import DateRange
-from ._generalslice import OPEN_OPEN, CLOSED_CLOSED, OPEN_CLOSED, CLOSED_OPEN, GeneralSlice
+from ._generalslice import OPEN_OPEN, CLOSED_CLOSED, OPEN_CLOSED, CLOSED_OPEN
 from ._parse import parse
 from ._mktz import mktz
 

--- a/arctic/decorators.py
+++ b/arctic/decorators.py
@@ -1,12 +1,15 @@
 from datetime import datetime
 from functools import wraps
 import os
-from pymongo.errors import AutoReconnect, OperationFailure, DuplicateKeyError, ServerSelectionTimeoutError
 import sys
 from time import sleep
+import logging
 
-from .logging import logger
+from pymongo.errors import AutoReconnect, OperationFailure, DuplicateKeyError, ServerSelectionTimeoutError
+
 from .hooks import _log_exception_hook as _log_exception
+
+logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 15
 
@@ -67,8 +70,8 @@ def dump_bad_documents(*document):
     """
     Dump bad documents to disk
     """
-    id = str(document[0]['_id'])
-    with open('/tmp/mongo_debug_' + str(os.getpid()) + '_' + id + '_' + str(datetime.now()), 'a') as f:
+    _id = str(document[0]['_id'])
+    with open('/tmp/mongo_debug_' + str(os.getpid()) + '_' + _id + '_' + str(datetime.now()), 'a') as f:
         for d in document:
             f.write(str(d) + '\n')
 

--- a/arctic/fixtures/arctic.py
+++ b/arctic/fixtures/arctic.py
@@ -1,12 +1,14 @@
 import getpass
+import logging
+
 import pytest as pytest
 
 from .. import arctic as m
-from ..logging import logger
-from ..decorators import mongo_retry
 from ..tickstore.tickstore import TICK_STORE_TYPE
 
 from .mongo import mongo_proc, mongodb
+
+logger = logging.getLogger(__name__)
 
 mongo_proc2 = mongo_proc(executable="mongod", port="?",
                          params='--nojournal '

--- a/arctic/fixtures/mongo.py
+++ b/arctic/fixtures/mongo.py
@@ -124,7 +124,7 @@ def mongodb(process_fixture_name):
         """
         proc_fixture = get_process_fixture(request, process_fixture_name)
 
-        pymongo, config = try_import('pymongo', request)
+        pymongo, _ = try_import('pymongo', request)
 
         mongo_host = proc_fixture.host
         mongo_port = proc_fixture.port

--- a/arctic/hosts.py
+++ b/arctic/hosts.py
@@ -1,17 +1,13 @@
 """
 Utilities to resolve a string to Mongo host, or a Arctic library.
 """
-import ConfigParser
-from ConfigParser import NoOptionError, NoSectionError
-import os
 import re
+import logging
 from weakref import WeakValueDictionary
-
-from .logging import logger
 
 __all__ = ['get_arctic_lib', 'get_arctic_for_library']
 
-
+logger = logging.getLogger(__name__)
 
 # Application environment variables
 arctic_cache = WeakValueDictionary()

--- a/arctic/logging.py
+++ b/arctic/logging.py
@@ -1,6 +1,0 @@
-from __future__ import absolute_import
-
-import logging as logger
-
-logger.basicConfig(format='%(asctime)s %(message)s', level='INFO')
-logger = logger.getLogger('arctic')

--- a/arctic/scripts/arctic_copy_data.py
+++ b/arctic/scripts/arctic_copy_data.py
@@ -1,15 +1,17 @@
 import argparse
 import os
-import re
+import logging
 from multiprocessing import Pool
 import pwd
 
 from arctic.decorators import _get_host
 from arctic.store.audit import ArcticTransaction
 
-from ..logging import logger
 from ..hosts import get_arctic_lib
 from ..date import DateRange, to_pandas_closed_closed, CLOSED_OPEN, OPEN_CLOSED
+from .utils import setup_logging
+
+logger = logging.getLogger(__name__)
 
 # Use the UID rather than environment variables for auditing
 USER = pwd.getpwuid(os.getuid())[0]
@@ -26,9 +28,9 @@ def copy_symbols_helper(src, dest, log, force, splice):
                     elif splice:
                         logger.warn("Symbol: %s already exists in destination, splicing in new data" % symbol)
                     else:
-                        logger.warn("Symbol: {} already exists in {}@{}, use --force to overwrite or --splice to join with existing data".format(symbol,
-                                                                                                                                                 _get_host(dest).get('l'),
-                                                                                                                                                 _get_host(dest).get('mhost')))
+                        logger.warn("Symbol: {} already exists in {}@{}, use --force to overwrite or --splice to join "
+                                    "with existing data".format(symbol, _get_host(dest).get('l'),
+                                                                _get_host(dest).get('mhost')))
                         continue
 
                 version = src.read(symbol)
@@ -36,8 +38,12 @@ def copy_symbols_helper(src, dest, log, force, splice):
 
                 if existing_data and splice:
                     original_data = dest.read(symbol).data
-                    before = original_data.ix[:to_pandas_closed_closed(DateRange(None, new_data.index[0].to_pydatetime(), interval=CLOSED_OPEN)).end]
-                    after = original_data.ix[to_pandas_closed_closed(DateRange(new_data.index[-1].to_pydatetime(), None, interval=OPEN_CLOSED)).start:]
+                    before = original_data.ix[:to_pandas_closed_closed(DateRange(None,
+                                                                                 new_data.index[0].to_pydatetime(),
+                                                                                 interval=CLOSED_OPEN)).end]
+                    after = original_data.ix[to_pandas_closed_closed(DateRange(new_data.index[-1].to_pydatetime(),
+                                                                               None,
+                                                                               interval=OPEN_CLOSED)).start:]
                     new_data = before.append(new_data).append(after)
 
                 mt.write(symbol, new_data, metadata=version.metadata)
@@ -51,6 +57,7 @@ def main():
     Example:
         arctic_copy_data --log "Copying data" --src user.library@host1 --dest user.library@host2 symbol1 symbol2
     """
+    setup_logging()
     p = argparse.ArgumentParser(usage=usage)
     p.add_argument("--src", required=True, help="Source MongoDB like: library@hostname:port")
     p.add_argument("--dest", required=True, help="Destination MongoDB like: library@hostname:port")
@@ -93,7 +100,6 @@ def main():
         pool.apply(copy_symbol, chunks)
     else:
         copy_symbol(required_symbols)
-
 
 
 if __name__ == '__main__':

--- a/arctic/scripts/arctic_delete_library.py
+++ b/arctic/scripts/arctic_delete_library.py
@@ -1,20 +1,23 @@
 import optparse
 import pymongo
+import logging
 
-from ..logging import logger
 from ..hooks import get_mongodb_uri
 from ..arctic import Arctic
-from .utils import do_db_auth
+from .utils import do_db_auth, setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main():
     usage = """usage: %prog [options]
-    
+
     Deletes the named library from a user's database.
 
     Example:
         %prog --host=hostname --library=arctic_jblackburn.my_library
     """
+    setup_logging()
 
     parser = optparse.OptionParser(usage=usage)
     parser.add_option("--host", default='localhost', help="Hostname, or clustername. Default: localhost")

--- a/arctic/scripts/arctic_enable_sharding.py
+++ b/arctic/scripts/arctic_enable_sharding.py
@@ -6,13 +6,15 @@ from ..auth import get_auth
 from ..hooks import get_mongodb_uri
 from .._util import enable_sharding
 from ..auth import authenticate
+from .utils import setup_logging
 
 
 def main():
     usage = """usage: %prog [options] arg1=value, arg2=value
-    
+
     Enables sharding on the specified arctic library.
     """
+    setup_logging()
 
     parser = optparse.OptionParser(usage=usage)
     parser.add_option("--host", default='localhost', help="Hostname, or clustername. Default: localhost")

--- a/arctic/scripts/arctic_fsck.py
+++ b/arctic/scripts/arctic_fsck.py
@@ -1,16 +1,18 @@
 import logging
 import argparse
 
-from ..logging import logger
 from ..hooks import get_mongodb_uri
 from ..arctic import Arctic, ArcticLibraryBinding
-from .utils import do_db_auth
+from .utils import do_db_auth, setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main():
     usage = """
     Check a Arctic Library for inconsistencies.
     """
+    setup_logging()
 
     parser = argparse.ArgumentParser(usage=usage)
     parser.add_argument("--host", default='localhost', help="Hostname, or clustername. Default: localhost")

--- a/arctic/scripts/arctic_init_library.py
+++ b/arctic/scripts/arctic_init_library.py
@@ -1,11 +1,13 @@
 import argparse
 import pymongo
+import logging
 
-from ..logging import logger
 from ..hooks import get_mongodb_uri
 from ..arctic import Arctic, VERSION_STORE, LIBRARY_TYPES, \
     ArcticLibraryBinding
-from .utils import do_db_auth
+from .utils import do_db_auth, setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def main():
@@ -15,6 +17,7 @@ def main():
     Example:
         arctic_init_library --host=hostname --library=arctic_jblackburn.my_library
     """
+    setup_logging()
 
     parser = argparse.ArgumentParser(usage=usage)
     parser.add_argument("--host", default='localhost', help="Hostname, or clustername. Default: localhost")

--- a/arctic/scripts/arctic_list_libraries.py
+++ b/arctic/scripts/arctic_list_libraries.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import optparse
 
 from ..arctic import Arctic
+from .utils import setup_logging
 
 print = print
 
@@ -15,6 +16,7 @@ def main():
     Example:
         %prog --host=hostname rgautier
     """
+    setup_logging()
 
     parser = optparse.OptionParser(usage=usage)
     parser.add_option("--host", default='localhost', help="Hostname, or clustername. Default: localhost")

--- a/arctic/scripts/arctic_prune_versions.py
+++ b/arctic/scripts/arctic_prune_versions.py
@@ -1,10 +1,12 @@
 import optparse
 import pymongo
+import logging
 
-from ..logging import logger
 from ..hooks import get_mongodb_uri
 from ..arctic import Arctic, ArcticLibraryBinding
-from .utils import do_db_auth
+from .utils import do_db_auth, setup_logging
+
+logger = logging.getLogger(__name__)
 
 
 def prune_versions(lib, symbol, keep_mins):
@@ -13,20 +15,20 @@ def prune_versions(lib, symbol, keep_mins):
 
 def main():
     usage = """usage: %prog [options]
-    
-    Prunes (i.e. deletes) versions of data that are not the most recent, and are older than 10 minutes, 
+
+    Prunes (i.e. deletes) versions of data that are not the most recent, and are older than 10 minutes,
     and are not in use by snapshots. Must be used on a Arctic VersionStore library instance.
 
     Example:
         arctic_prune_versions --host=hostname --library=arctic_jblackburn.my_library
     """
+    setup_logging()
 
     parser = optparse.OptionParser(usage=usage)
     parser.add_option("--host", default='localhost', help="Hostname, or clustername. Default: localhost")
     parser.add_option("--library", help="The name of the library. e.g. 'arctic_jblackburn.library'")
     parser.add_option("--symbols", help="The symbols to prune - comma separated (default all)")
     parser.add_option("--keep-mins", default=10, help="Ensure there's a version at least keep-mins old. Default:10")
-
 
     (opts, _) = parser.parse_args()
 

--- a/arctic/scripts/utils.py
+++ b/arctic/scripts/utils.py
@@ -1,5 +1,10 @@
-from ..logging import logger
+from __future__ import absolute_import
+
+import logging
+
 from ..auth import get_auth, authenticate
+
+logger = logging.getLogger(__name__)
 
 
 def do_db_auth(host, connection, db_name):
@@ -32,3 +37,9 @@ def do_db_auth(host, connection, db_name):
     # Ensure we attempt to auth against the user DB, for non-priviledged users to get access
     authenticate(connection[db_name], user_creds.user, user_creds.password)
     return True
+
+
+def setup_logging():
+    """ Logging setup for console scripts
+    """
+    logging.basicConfig(format='%(asctime)s %(message)s', level='INFO')

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -1,9 +1,11 @@
+import logging
+
 from _ndarray_store import NdarrayStore
 from pandas import DataFrame, MultiIndex, Series, DatetimeIndex, Panel
 from pandas.tslib import Timestamp, get_timezone
 import numpy as np
 
-from ..logging import logger as log
+log = logging.getLogger(__name__)
 
 
 def _to_primitive(arr):
@@ -142,7 +144,6 @@ class PandasDataFrameStore(PandasStore):
         column_vals = [df[c].values for c in df.columns]
         return columns, column_vals
 
-
     def from_records(self, recarr):
         index = self._index_from_records(recarr)
         column_fields = [x for x in recarr.dtype.names if x not in recarr.dtype.metadata['index']]
@@ -171,6 +172,7 @@ class PandasDataFrameStore(PandasStore):
     def read(self, arctic_lib, version, symbol, **kwargs):
         item = super(PandasDataFrameStore, self).read(arctic_lib, version, symbol, **kwargs)
         return self.from_records(item)
+
 
 class PandasPanelStore(PandasDataFrameStore):
     TYPE = 'pandaspan'

--- a/arctic/store/audit.py
+++ b/arctic/store/audit.py
@@ -1,6 +1,7 @@
 """
 Handle audited data changes.
 """
+import logging
 from functools import partial
 
 from pymongo.errors import OperationFailure
@@ -8,8 +9,9 @@ from pymongo.errors import OperationFailure
 from .._util import are_equals
 from ..decorators import _get_host
 from ..exceptions import NoDataFoundException, ConcurrentModificationException
-from ..logging import logger
 from .versioned_item import VersionedItem, ChangedItem
+
+logger = logging.getLogger(__name__)
 
 
 class DataChange(object):
@@ -115,7 +117,7 @@ class ArcticTransaction(object):
             if self.base_ts.data is None or not are_equals(data, self.base_ts.data) or metadata != self.base_ts.metadata:
                 self._do_write = True
         self._write = partial(self._version_store.write, symbol, data, prune_previous_version=prune_previous_version,
-                                        metadata=metadata, **kwargs)
+                              metadata=metadata, **kwargs)
 
     def __enter__(self):
         return self

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -1,3 +1,5 @@
+import logging
+
 from bson.binary import Binary
 from datetime import datetime as dt, timedelta
 import lz4
@@ -6,15 +8,13 @@ import pandas as pd
 from pandas.core.frame import _arrays_to_mgr
 import pymongo
 from pymongo.errors import OperationFailure
-import pytz
 
 from ..date import DateRange, to_pandas_closed_closed, mktz, datetime_to_ms, ms_to_datetime
 from ..decorators import mongo_retry
-from ..exceptions import OverlappingDataException, \
-        NoDataFoundException, UnhandledDtypeException, ArcticException
-from ..logging import logger
+from ..exceptions import OverlappingDataException, NoDataFoundException, UnhandledDtypeException, ArcticException
 from .._util import indent
 
+logger = logging.getLogger(__name__)
 
 # Example-Schema:
 # --------------

--- a/arctic/tickstore/toplevel.py
+++ b/arctic/tickstore/toplevel.py
@@ -1,16 +1,18 @@
+import logging
 import bisect
 from collections import namedtuple
 from datetime import datetime as dt, date, time, timedelta
-import pandas as pd
-import pymongo
 import re
 from timeit import itertools
 
-from ..date import mktz, DateRange, OPEN_OPEN, CLOSED_CLOSED
-from ..exceptions import NoDataFoundException, UnhandledDtypeException, OverlappingDataException, \
-                    LibraryNotFoundException
-from ..logging import logger
+import pandas as pd
+import pymongo
 
+from ..date import mktz, DateRange, OPEN_OPEN, CLOSED_CLOSED
+from ..exceptions import (NoDataFoundException, UnhandledDtypeException, OverlappingDataException,
+                          LibraryNotFoundException)
+
+logger = logging.getLogger(__name__)
 
 TickStoreLibrary = namedtuple("TickStoreLibrary", ["library", "date_range"])
 
@@ -41,7 +43,6 @@ class TopLevelTickStore(object):
         tl = TopLevelTickStore(arctic_lib)
         tl._add_libraries()
         tl._ensure_index()
-
 
     def _ensure_index(self):
         collection = self._collection
@@ -172,5 +173,5 @@ overlapping libraries: {}""".format(library_name, [l.library for l in library_me
         return [TickStoreLibrary(res['library_name'], DateRange(res['start'], res['end'], CLOSED_CLOSED))
                 for res in self._collection.find(query,
                                                  projection={'library_name': 1,
-                                                         'start': 1, 'end': 1},
+                                                             'start': 1, 'end': 1},
                                                  sort=[('start', pymongo.ASCENDING)])]

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 
-import os
+import logging
 from setuptools import setup, Extension
 from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
@@ -43,13 +43,16 @@ class PyTest(TestCommand):
         self.test_suite = True
 
     def run_tests(self):
+        logging.basicConfig(format='%(asctime)s %(levelname)s %(name)s %(message)s', level='DEBUG')
+
         # import here, cause outside the eggs aren't loaded
         import pytest
+
         args = [self.pytest_args] if isinstance(self.pytest_args, basestring) else list(self.pytest_args)
         args.extend(['--cov', 'arctic',
                      '--cov-report', 'xml',
                      '--cov-report', 'html',
-                     '--junitxml', 'junit.xml'
+                     '--junitxml', 'junit.xml',
                      ])
         errno = pytest.main(args)
         sys.exit(errno)

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -134,7 +134,7 @@ def test_quota(arctic, library, library_name):
 
 
 def test_check_quota(arctic, library, library_name):
-    with patch('arctic.logging.logger.info') as info:
+    with patch('arctic.arctic.logger.info') as info:
         arctic.check_quota(library_name)
     assert info.call_count == 1
 

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -198,7 +198,7 @@ def test_check_quota():
                                                                               'count': 100,
                                                                               }
                                                                              }))
-    with patch('arctic.logging.logger.warn') as warn:
+    with patch('arctic.arctic.logger.warn') as warn:
         ArcticLibraryBinding.check_quota(self)
     self.arctic.__getitem__.assert_called_once_with(self.get_name.return_value)
     warn.assert_called_once_with('Mongo Quota: 0.879 / 1 GB used')
@@ -215,7 +215,7 @@ def test_check_quota_info():
                                                                               'count': 100,
                                                                               }
                                                                              }))
-    with patch('arctic.logging.logger.info') as info:
+    with patch('arctic.arctic.logger.info') as info:
         ArcticLibraryBinding.check_quota(self)
     self.arctic.__getitem__.assert_called_once_with(self.get_name.return_value)
     info.assert_called_once_with('Mongo Quota: 0.001 / 1 GB used')


### PR DESCRIPTION
Makes the library a bit more downstream-user friendly wrt the use of logging - basically removes the singleton logger and only calls logging.basicConfig for the console scripts.
Also a bunch of little PEP8 fixes.