### PR TITLE
Ensure Arctic.__getstate__ persists all init params.

### DIFF
--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -130,7 +130,12 @@ class Arctic(object):
         return str(self)
 
     def __getstate__(self):
-        return {'mongo_host': self.mongo_host, 'allow_secondary': self._allow_secondary}
+        return {'mongo_host': self.mongo_host,
+                'app_name': self._application_name,
+                'allow_secondary': self._allow_secondary,
+                'socketTimeoutMS': self._socket_timeout,
+                'connectTimeoutMS': self._connect_timeout,
+                'serverSelectionTimeoutMS': self._server_selection_timeout}
 
     def __setstate__(self, state):
         return Arctic.__init__(self, **state)

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -326,8 +326,13 @@ def test_mongo_host_get_set():
 
 def test_arctic_set_get_state():
     sentinel.mongo_host = Mock(nodes={("host", "port")})
-    store = Arctic(sentinel.mongo_host, allow_secondary="allow_secondary")
+    store = Arctic(sentinel.mongo_host, allow_secondary="allow_secondary", app_name="app_name", 
+                   socketTimeoutMS=1234, connectTimeoutMS=2345, serverSelectionTimeoutMS=3456)
     buff = pickle.dumps(store)
     mnew = pickle.loads(buff)
     assert mnew.mongo_host == "host:port"
     assert mnew._allow_secondary == "allow_secondary"
+    assert mnew._application_name == "app_name"
+    assert mnew._socket_timeout == 1234
+    assert mnew._connect_timeout == 2345
+    assert mnew._server_selection_timeout == 3456


### PR DESCRIPTION
It previously dropped app_name and the various timeout params.