### PR TITLE
MDP-341 ensure the external error hook is called when an exception occurs

### DIFF
--- a/arctic/decorators.py
+++ b/arctic/decorators.py
@@ -7,7 +7,7 @@ import logging
 
 from pymongo.errors import AutoReconnect, OperationFailure, DuplicateKeyError, ServerSelectionTimeoutError
 
-from .hooks import _log_exception_hook as _log_exception
+from .hooks import log_exception as _log_exception
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
Call the hook via hooks.py rather than importing it into decorators.