### PR TITLE
Bugfix/mdp 568 pandas date-range read issues in arctic

### DIFF
--- a/arctic/date/_util.py
+++ b/arctic/date/_util.py
@@ -106,10 +106,21 @@ def to_dt(date, default_tz=None):
     return date
 
 
-def to_pandas_closed_closed(date_range):
+def to_pandas_closed_closed(date_range, add_tz=True):
     """
     Pandas DateRange slicing is CLOSED-CLOSED inclusive at both ends.
 
+    Parameters
+    ----------
+    date_range : `DateRange` object 
+        converted to CLOSED_CLOSED form for Pandas slicing
+
+    add_tz : `bool`
+        Adds a TimeZone to the daterange start and end if it doesn't
+        have one.
+
+    Returns
+    -------
     Returns a date_range with start-end suitable for slicing in pandas.
     """
     if not date_range:
@@ -118,12 +129,12 @@ def to_pandas_closed_closed(date_range):
     start = date_range.start
     end = date_range.end
     if start:
-        start = to_dt(start, mktz())  # Ensure they have timezones
+        start = to_dt(start, mktz()) if add_tz else start
         if date_range.startopen:
             start += timedelta(milliseconds=1)
 
     if end:
-        end = to_dt(end, mktz())  # Ensure they have timezones
+        end = to_dt(end, mktz()) if add_tz else end
         if date_range.endopen:
             end -= timedelta(milliseconds=1)
     return DateRange(start, end)

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -171,8 +171,8 @@ class PandasStore(NdarrayStore):
                 start, end = _start_end(date_range, dts)
                 if start > dts[-1]:
                     return -1, -1
-                idxstart = min(np.searchsorted(dts, start), len(dts))
-                idxend = min(np.searchsorted(dts, end), len(dts))
+                idxstart = min(np.searchsorted(dts, start), len(dts) - 1)
+                idxend = min(np.searchsorted(dts, end), len(dts) - 1)
                 return index['index'][idxstart], index['index'][idxend] + 1
         return super(PandasStore, self)._index_range(version, symbol, **kwargs)
 

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -203,10 +203,17 @@ def _start_end(date_range, dts):
     """
     # FIXME: timezones
     assert len(dts)
-    date_range = to_pandas_closed_closed(date_range)
+    _assert_no_timezone(date_range)
+    date_range = to_pandas_closed_closed(date_range, add_tz=False)
     start = np.datetime64(date_range.start) if date_range.start else dts[0]
     end = np.datetime64(date_range.end) if date_range.end else dts[-1]
     return start, end
+
+
+def _assert_no_timezone(date_range):
+    for _dt in (date_range.start, date_range.end):
+        if _dt and _dt.tzinfo is not None:
+            raise ValueError("DateRange with timezone not supported")
 
 
 class PandasSeriesStore(PandasStore):

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -663,6 +663,9 @@ def test_daterange_large_DataFrame(library):
     # last row
     result = library.read('MYARR', date_range=DateRange(df.index[-1], df.index[-1])).data
     assert_frame_equal(df[df.index[-1]:df.index[-1]], result, check_names=False)
+    # beyond last row
+    result = library.read('MYARR', date_range=DateRange(df.index[-1], df.index[-1] + dtd(days=1))).data
+    assert_frame_equal(df[df.index[-1]:df.index[-1]], result, check_names=False)
     # somewhere in time
     result = library.read('MYARR', date_range=DateRange(dt(2020, 1, 1), dt(2031, 9, 1))).data
     assert_frame_equal(df[dt(2020, 1, 1):dt(2031, 9, 1)], result, check_names=False)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -10,7 +10,7 @@ import itertools
 from mock import Mock, patch
 import string
 
-from arctic.date import DateRange
+from arctic.date import DateRange, mktz
 from arctic._compression import decompress
 from arctic.store._pandas_ndarray_store import PandasDataFrameStore, PandasSeriesStore, PandasStore
 from arctic.store.version_store import register_versioned_storage
@@ -603,7 +603,7 @@ def test_not_unique(library):
     ts2 = library.read('ts').data
     assert_frame_equal(ts, ts2)
 
-    
+
 def test_daterange_end(library):
     df = DataFrame(index=date_range(dt(2001, 1, 1), freq='S', periods=30 * 1024),
                    data=np.tile(np.arange(30 * 1024), 100).reshape((-1, 100)))
@@ -718,7 +718,7 @@ def test_daterange(library, df, assert_equal):
     assert len(library.read('MYARR', date_range=DateRange(dt(1950, 1, 1), dt(1951, 1, 1))).data) == 0
     assert len(library.read('MYARR', date_range=DateRange(dt(2091, 1, 1), dt(2091, 1, 1))).data) == 0
 
-    
+
 def test_daterange_append(library):
     df = DataFrame(index=date_range(dt(2001, 1, 1), freq='S', periods=30 * 1024),
                    data=np.tile(np.arange(30 * 1024), 100).reshape((-1, 100)))
@@ -747,4 +747,53 @@ def test_daterange_append(library):
     assert_frame_equal(concat((df, rows, rows1))[df.index[50]:rows1.index[-2]],
                        library.read('MYARR', date_range=DateRange(start=df.index[50], end=rows1.index[-2])).data)
 
+
+def assert_range_slice(library, expected, date_range, **kwargs):
+    assert_equals = assert_series_equal if isinstance(expected, Series) else assert_frame_equal
+    assert_equals(expected, library.read('MYARR', date_range=date_range).data, **kwargs)
+
+
+def test_daterange_single_chunk(library):
+    df = read_csv(StringIO("""2015-08-10 00:00:00,200005,1.0
+                              2015-08-10 00:00:00,200012,2.0
+                              2015-08-10 00:00:00,200016,3.0
+                              2015-08-11 00:00:00,200005,1.0
+                              2015-08-11 00:00:00,200012,2,0
+                              2015-08-11 00:00:00,200016,3.0"""), parse_dates=[0],
+                  names=['date', 'security_id', 'value']).set_index(['date', 'security_id'])
+    library.write('MYARR', df)
+    assert_range_slice(library, df[dt(2015, 8, 11):], DateRange(dt(2015, 8, 11), dt(2015, 8, 11)))
+
+
+def test_daterange_when_end_beyond_chunk_index(library):
+    df = read_csv(StringIO("""2015-08-10 00:00:00,200005,1.0
+                              2015-08-10 00:00:00,200012,2.0
+                              2015-08-10 00:00:00,200016,3.0
+                              2015-08-11 00:00:00,200005,1.0
+                              2015-08-11 00:00:00,200012,2,0
+                              2015-08-11 00:00:00,200016,3.0"""), parse_dates=[0],
+                  names=['date', 'security_id', 'value']).set_index(['date', 'security_id'])
+    library.write('MYARR', df)
+    assert_range_slice(library, df[dt(2015, 8, 11):], DateRange(dt(2015, 8, 11), dt(2015, 8, 12)))
+
+
+def test_daterange_when_end_beyond_chunk_index_no_start(library):
+    df = read_csv(StringIO("""2015-08-10 00:00:00,200005,1.0
+                              2015-08-10 00:00:00,200012,2.0
+                              2015-08-10 00:00:00,200016,3.0
+                              2015-08-11 00:00:00,200005,1.0
+                              2015-08-11 00:00:00,200012,2,0
+                              2015-08-11 00:00:00,200016,3.0"""), parse_dates=[0],
+                  names=['date', 'security_id', 'value']).set_index(['date', 'security_id'])
+    library.write('MYARR', df)
+    assert_range_slice(library, df, DateRange(end=dt(2015, 8, 12)))
+
+
+def test_daterange_fails_with_timezone_start(library):
+    df = read_csv(StringIO("""2015-08-10 00:00:00,200005,1.0
+                              2015-08-11 00:00:00,200016,3.0"""), parse_dates=[0],
+                  names=['date', 'security_id', 'value']).set_index(['date', 'security_id'])
+    library.write('MYARR', df)
+    with pytest.raises(ValueError):
+        library.read('MYARR', date_range=DateRange(start=dt(2015, 1, 1, tzinfo=mktz())))
 


### PR DESCRIPTION
- Fix index out of bounds error when reading beyond the end of a chunk
- We don't current support TimeZones for DateRange slicing