### PR TITLE
Speedup saving of Pandas Series/Dataframes with MultiIndex containing a date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,16 @@
 
 ## Changelog
 
+### 1.11 (2015-10-29)
+
+  * Bugfix: Improve performance of saving multi-index Pandas DataFrames
+    by 9x
+
+### 1.10 (2015-10-28)
+
+  * Bugfix: VersionStore.read(date_range=...) could do the wrong thing with
+    TimeZones (which aren't yet supported for date_range slicing.).
+
 ### 1.9 (2015-10-06)
 
   * Bugfix: fix authentication race condition when sharing an Arctic

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -21,7 +21,7 @@ def _to_primitive(arr):
     if arr.dtype.hasobject:
         if len(arr) > 0:
             if isinstance(arr[0], Timestamp):
-                return arr.astype(DTN64_DTYPE)
+                return np.array([t.value for t in arr], dtype=DTN64_DTYPE)
         return np.array(list(arr))
     return arr
 
@@ -35,7 +35,7 @@ class PandasStore(NdarrayStore):
         if isinstance(index, MultiIndex):
             # array of tuples to numpy cols. copy copy copy
             if len(df) > 0:
-                ix_vals = map(np.array, zip(*index.values))
+                ix_vals = map(np.array, [index.get_level_values(i) for i in range(index.nlevels)])
             else:
                 # empty multi index has no size, create empty arrays for recarry..
                 ix_vals = [np.array([]) for n in index.names]


### PR DESCRIPTION
From Tom: Saving a 3GB multi-index Pandas DF takes >10 minutes:

```
from pandas import DataFrame, date_range
from datetime import datetime as dt
from itertools import product
import numpy as np
from pandas.tools.util import cartesian_product
 
dates = date_range(dt(2000, 1, 1), dt(2015, 1, 1))
ids = range(6000)
idx = cartesian_product((dates, ids))
 
df = DataFrame(index=idx)
for c in range(12):
    df['c_%s' % c] = np.random.randn(len(df))
 
size = (df.values.nbytes + df.index.nbytes + df.columns.nbytes) / 1e6
print size
 
from arctic import Arctic
from datetime import datetime as dt
m = Arctic('research')['tptaylor.alphas']
now = dt.now()
m.write('xx', df)
print dt.now() – now
```

![output](https://cloud.githubusercontent.com/assets/55716/10813660/85c55370-7e18-11e5-8720-80811e8d989a.png)