### PR TITLE
MDP-574 Only catch OperationFailure exceptions during auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 
   * Bugfix: Improve performance of saving multi-index Pandas DataFrames
     by 9x
+  * Bugfix: authenticate should propagate non-OperationFailure exceptions
+    (e.g. ConnectionFailure) as this might be indicative of socket failures
 
 ### 1.10 (2015-10-28)
 

--- a/arctic/auth.py
+++ b/arctic/auth.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 import logging
+from pymongo.errors import OperationFailure
 
 logger = logging.getLogger(__name__)
 
@@ -10,11 +11,10 @@ def authenticate(db, user, password):
 
     PyMongo 2.6 changed the auth API to raise on Auth failure.
     """
-    from pymongo.errors import PyMongoError
     try:
         logger.debug("Authenticating {} with {}".format(db, user))
         return db.authenticate(user, password)
-    except PyMongoError, e:
+    except OperationFailure as e:
         logger.debug("Auth Error %s" % e)
     return False
 

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -1,6 +1,7 @@
 from mock import create_autospec, sentinel
 from pymongo.database import Database
-from pymongo.errors import PyMongoError
+from pymongo.errors import PyMongoError, OperationFailure
+import pytest
 
 from arctic import auth
 
@@ -13,5 +14,13 @@ def test_authenticate():
 
 def test_authenticate_fails():
     db = create_autospec(Database)
-    db.authenticate.side_effect = PyMongoError("error")
+    error = "command SON([('saslStart', 1), ('mechanism', 'SCRAM-SHA-1'), ('payload', Binary('n,,n=foo,r=OTI3MzA3MTEzMTIx', 0)), ('autoAuthorize', 1)]) on namespace admin.$cmd failed: Authentication failed."
+    db.authenticate.side_effect = OperationFailure(error)
     assert auth.authenticate(db, sentinel.user, sentinel.password) is False
+
+
+def test_authenticate_fails_exception():
+    db = create_autospec(Database)
+    db.authenticate.side_effect = PyMongoError("error")
+    with pytest.raises(PyMongoError):
+        assert auth.authenticate(db, sentinel.user, sentinel.password) is False


### PR DESCRIPTION
Other derivatives of PyMongoError indicate other issues, so rather than
silently hide them, we should propagate them to the caller.