### PR TITLE
EASY-511 return deleted state in list_versions

### DIFF
--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -303,6 +303,26 @@ def test_list_version(library):
         assert versions[i]['version'] == x
 
 
+def test_list_version_deleted(library):
+    assert len(library.list_versions(symbol)) == 0
+    library.write(symbol, ts1, prune_previous_version=False)
+    assert len(library.list_versions(symbol)) == 1
+    # Snapshot the library so we keep the sentinel version
+    library.snapshot('xxx', versions={symbol: 1})
+    library.delete(symbol)
+    versions = library.list_versions(symbol)
+    assert len(versions) == 2
+    assert versions[0]['symbol'] == symbol
+    assert versions[0]['version'] == 2
+    assert versions[0]['snapshots'] == []
+    assert versions[0]['deleted'] == True
+
+    assert versions[1]['symbol'] == symbol
+    assert versions[1]['version'] == 1
+    assert versions[1]['deleted'] == False
+    assert versions[1]['snapshots'] == ['xxx']
+
+
 def test_list_version_latest_only(library):
     assert len(list(library.list_versions(symbol))) == 0
     dates = [None, None, None]

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -34,14 +34,15 @@ def test_list_versions_localTime():
     vs._find_snapshots.return_value = 'snap'
     date = dt(2013, 4, 1, 9, 0)
     vs._versions.find.return_value = [{'_id': bson.ObjectId.from_datetime(date),
-                                       'symbol': 's', 'version': 10}]
+                                       'symbol': 's', 'version': 10, 'metadata': None}]
 
     version = list(VersionStore.list_versions(vs, "symbol"))[0]
     local_date = date.replace(tzinfo=mktz("UTC"))
     assert version == {'symbol': version['symbol'], 'version': version['version'],
                        # We return naive datetimes in 'default' time, which is London for us
                        'date': local_date,
-                       'snapshots': 'snap'}
+                       'snapshots': 'snap',
+                       'deleted': False}
 
 
 def test__read_preference__allow_secondary_true():


### PR DESCRIPTION
This way we can check whether or not the leading version is just a sentinel put in by version_store.delete(). 