### PR TITLE
Remove the version pin for mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
                       "pytz",
                       "tzlocal",
                       ],
-    tests_require=["mock<=1.0.1",
+    tests_require=["mock",
                    "mockextras",
                    "pytest",
                    "pytest-cov",


### PR DESCRIPTION
this was there because mockextras didn't work with the latest version of mock but now it does