### PR TITLE
Python 3.4 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - "2.7"
   - "3.3"
+  - "3.4"
 install:
   - pip install --upgrade pip
   - pip install python-dateutil --upgrade 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 
 Arctic currently works with:
 
- * Python 2.7 or 3.3
+ * Python 2.7, 3.3, 3.4
  * pymongo >= 3.0
  * Pandas
  * MongoDB >= 2.4.x

--- a/setup.py
+++ b/setup.py
@@ -120,6 +120,7 @@ setup(
         "License :: OSI Approved :: GNU Library or Lesser General Public License (LGPL)",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
+        "Programming LAnguage :: Python :: 3.4",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Cython",
         "Operating System :: POSIX",


### PR DESCRIPTION
A few other changes now that Python 3.4 is supported (thanks to the changes that allow us to support Mock 1.3.0)