### PR TITLE
Top level read fix for #95

### DIFF
--- a/arctic/tickstore/toplevel.py
+++ b/arctic/tickstore/toplevel.py
@@ -100,8 +100,16 @@ overlapping libraries: {}""".format(library_name, [l.library for l in library_me
 
     def read(self, symbol, date_range, columns=['BID', 'ASK', 'TRDPRC_1', 'BIDSIZE', 'ASKSIZE', 'TRDVOL_1'], include_images=False):
         libraries = self._get_libraries(date_range)
-        dfs = [l.library.read(symbol, l.date_range.intersection(date_range), columns,
-                              include_images=include_images) for l in libraries]
+        dfs = []
+        for l in libraries:
+            try:
+                df = l.library.read(symbol, l.date_range.intersection(date_range), columns,
+                                    include_images=include_images)
+                dfs.append(df)
+            except NoDataFoundException, e:
+                continue
+        if len(dfs) == 0:
+            raise NoDataFoundException("No Data found for {} in range: {}".format(symbol, date_range))
         return pd.concat(dfs)
 
     def write(self, symbol, data):

--- a/arctic/tickstore/toplevel.py
+++ b/arctic/tickstore/toplevel.py
@@ -106,7 +106,7 @@ overlapping libraries: {}""".format(library_name, [l.library for l in library_me
                 df = l.library.read(symbol, l.date_range.intersection(date_range), columns,
                                     include_images=include_images)
                 dfs.append(df)
-            except NoDataFoundException, e:
+            except NoDataFoundException as e:
                 continue
         if len(dfs) == 0:
             raise NoDataFoundException("No Data found for {} in range: {}".format(symbol, date_range))

--- a/tests/integration/tickstore/test_toplevel.py
+++ b/tests/integration/tickstore/test_toplevel.py
@@ -71,12 +71,8 @@ def test_should_return_data_when_date_range_spans_libraries(toplevel_tickstore, 
     arctic.initialize_library('FEED_2011.LEVEL1', tickstore.TICK_STORE_TYPE)
     tickstore_2010 = arctic['FEED_2010.LEVEL1']
     tickstore_2011 = arctic['FEED_2011.LEVEL1']
-    toplevel_tickstore._collection.insert_one({'start': dt(2010, 1, 1),
-                                           'end': dt(2010, 12, 31, 23, 59, 59),
-                                           'library_name': 'FEED_2010.LEVEL1'})
-    toplevel_tickstore._collection.insert_one({'start': dt(2011, 1, 1),
-                                           'end': dt(2011, 12, 31, 23, 59, 59),
-                                           'library_name': 'FEED_2011.LEVEL1'})
+    toplevel_tickstore.add(DateRange(start=dt(2010, 1, 1), end=dt(2010, 12, 31, 23, 59, 59, 999000)), 'FEED_2010.LEVEL1')
+    toplevel_tickstore.add(DateRange(start=dt(2011, 1, 1), end=dt(2011, 12, 31, 23, 59, 59, 999000)), 'FEED_2011.LEVEL1')
     dates = pd.date_range('20100101', periods=6, tz=mktz('Europe/London'))
     df_10 = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list('ABCD'))
     tickstore_2010.write('blah', df_10)
@@ -93,12 +89,8 @@ def test_should_return_data_when_date_range_spans_libraries_even_if_one_returns_
     arctic.initialize_library('FEED_2011.LEVEL1', tickstore.TICK_STORE_TYPE)
     tickstore_2010 = arctic['FEED_2010.LEVEL1']
     tickstore_2011 = arctic['FEED_2011.LEVEL1']
-    toplevel_tickstore._collection.insert_one({'start': dt(2010, 1, 1),
-                                           'end': dt(2010, 12, 31, 23, 59, 59),
-                                           'library_name': 'FEED_2010.LEVEL1'})
-    toplevel_tickstore._collection.insert_one({'start': dt(2011, 1, 1),
-                                           'end': dt(2011, 12, 31, 23, 59, 59),
-                                           'library_name': 'FEED_2011.LEVEL1'})
+    toplevel_tickstore.add(DateRange(start=dt(2010, 1, 1), end=dt(2010, 12, 31, 23, 59, 59, 999000)), 'FEED_2010.LEVEL1')
+    toplevel_tickstore.add(DateRange(start=dt(2011, 1, 1), end=dt(2011, 12, 31, 23, 59, 59, 999000)), 'FEED_2011.LEVEL1')
     dates = pd.date_range('20100101', periods=6, tz=mktz('Europe/London'))
     df_10 = pd.DataFrame(np.random.randn(6, 4), index=dates, columns=list('ABCD'))
     tickstore_2010.write('blah', df_10)


### PR DESCRIPTION
A read across two or more lower level tickstore libraries where one of them contained no data would raise a NoDataFoundException even though the others had returned data. This change fixes the bug and returns data.
@bmoscon @jamesblackburn 