### PR TITLE
Fix pandas write

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -540,7 +540,7 @@ class TickStore(object):
 
     def _pandas_to_bucket(self, df, symbol):
         start = to_dt(df.index[0].to_datetime())
-        end = to_dt(df.index[0].to_datetime())
+        end = to_dt(df.index[-1].to_datetime())
         rtn = {START: start, END: end, SYMBOL: symbol}
         rtn[VERSION] = CHUNK_VERSION_NUMBER
         rtn[COUNT] = len(df)

--- a/tests/integration/tickstore/test_ts_write.py
+++ b/tests/integration/tickstore/test_ts_write.py
@@ -8,6 +8,8 @@ from arctic import arctic as m
 from arctic.date import mktz
 from arctic.exceptions import OverlappingDataException, \
     NoDataFoundException
+from arctic.tickstore.tickstore import SYMBOL, START, END, COUNT, COLUMNS
+from tests.util import read_str_as_pandas
 
 
 DUMMY_DATA = [
@@ -77,3 +79,27 @@ def test_ts_write_pandas(tickstore_lib):
 
     read = tickstore_lib.read('SYM', columns=None)
     assert_frame_equal(read, data, check_names=False)
+
+
+def test_to_bucket(tickstore_lib):
+    bucket = tickstore_lib._to_bucket(DUMMY_DATA, 'SYM')
+    assert bucket[SYMBOL] == 'SYM'
+    assert bucket[START] == dt(2013, 1, 1, tzinfo=mktz('Europe/London'))
+    assert bucket[END] == dt(2013, 7, 5, tzinfo=mktz('Europe/London'))
+    assert bucket[COUNT] == 5
+
+
+def test_pandas_to_bucket(tickstore_lib):
+    df = read_str_as_pandas("""             index | near
+                   2012-09-08 17:06:11 |  1.0
+                   2012-10-08 17:06:11 |  2.0
+                   2012-10-09 17:06:11 |  2.5
+                   2012-11-08 17:06:11 |  3.0""")
+    df = df.tz_localize('UTC')
+    bucket = tickstore_lib._pandas_to_bucket(df, 'SYM')
+    assert bucket[SYMBOL] == 'SYM'
+    assert bucket[START] == dt(2012, 9, 8, 17, 6, 11, tzinfo=mktz('UTC'))
+    assert bucket[END] == dt(2012, 11, 8, 17, 6, 11, tzinfo=mktz('UTC'))
+    assert bucket[COUNT] == 4
+    assert bucket[COLUMNS].keys() == ['near']
+

--- a/tests/integration/tickstore/test_ts_write.py
+++ b/tests/integration/tickstore/test_ts_write.py
@@ -101,5 +101,6 @@ def test_pandas_to_bucket(tickstore_lib):
     assert bucket[START] == dt(2012, 9, 8, 17, 6, 11, tzinfo=mktz('UTC'))
     assert bucket[END] == dt(2012, 11, 8, 17, 6, 11, tzinfo=mktz('UTC'))
     assert bucket[COUNT] == 4
-    assert bucket[COLUMNS].keys() == ['near']
+    assert len(bucket[COLUMNS]) == 1
+    assert 'near' in bucket[COLUMNS]
 


### PR DESCRIPTION
Adding tests to detect doc['e'] being set incorrectly. Changing code in tickstore.py to fix the bug.

It seems that assert_frame_equal occasionally raises in error, I don't think my changes have caused this.