### PR TITLE
Use mergesort for Index sorting.

### DIFF
--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -4,7 +4,7 @@ import dateutil
 import tzlocal
 
 DEFAULT_TIME_ZONE_NAME = tzlocal.get_localzone().zone  # 'Europe/London'
-TIME_ZONE_DATA_SOURCE = '/usr/share/zoneinfo/'
+TIME_ZONE_DATA_SOURCE = u'/usr/share/zoneinfo/'
 
 
 class TimezoneError(Exception):

--- a/arctic/store/bitemporal_store.py
+++ b/arctic/store/bitemporal_store.py
@@ -90,7 +90,7 @@ class BitemporalStore(object):
             existing_item = self._store.read(symbol, **kwargs)
             if metadata is None:
                 metadata = existing_item.metadata
-            df = existing_item.data.append(data).sort_index()
+            df = existing_item.data.append(data).sort_index(kind='mergesort')
         self._store.write(symbol, df, metadata=metadata, prune_previous_version=True)
 
     def write(self, *args, **kwargs):

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -286,7 +286,7 @@ class TickStore(object):
             arrays = [[] for k in columns]
 
         if multiple_symbols:
-            sort = np.argsort(index)
+            sort = np.argsort(index, kind='mergesort')
             index = index[sort]
             arrays = [a[sort] for a in arrays]
 
@@ -302,7 +302,7 @@ class TickStore(object):
         logger.info("%d rows in %s secs: %s ticks/sec" % (ticks, t, int(ticks / t)))
         if not rtn.index.is_monotonic:
             logger.error("TimeSeries data is out of order, sorting!")
-            rtn = rtn.sort_index()
+            rtn = rtn.sort_index(kind='mergesort')
         if date_range:
             # FIXME: support DateRange.interval...
             rtn = rtn.ix[date_range.start:date_range.end]

--- a/tests/integration/store/test_bitemporal_store.py
+++ b/tests/integration/store/test_bitemporal_store.py
@@ -234,7 +234,6 @@ def test_multi_index_ts_read_raw(bitemporal_library):
                          2012-10-09 17:06:11.040 | SPAM Index |  2015-01-01 |  2.5
                          2012-11-08 17:06:11.040 | SPAM Index |  2015-01-01 |  3.0""", num_index=3)
     bitemporal_library.update('spam', ts, as_of=dt(2015, 1, 1))
-    ret = bitemporal_library.read('spam', raw=True).data
     assert_frame_equal(expected_ts.tz_localize(tz=LOCAL_TZ, level=2), bitemporal_library.read('spam', raw=True).data)
 
 


### PR DESCRIPTION
We want to ensure that data with identical timestamp isn't unnecessarily
perturbed.  Merge sort provides a stable sort:
http://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.sort_index.html#pandas.DataFrame.sort_index