### PR TITLE
Fix column naming issue #113

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.22 (2016-03-23)
+
+  * Bugfix: #113 Fix dataframe default column and series default name issues
+
 ### 1.21 (2016-03-08)
 
   * Bugfix: #106 Fix Pandas Panel storage for panels with different dimensions

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -4,7 +4,7 @@ import dateutil
 import tzlocal
 
 DEFAULT_TIME_ZONE_NAME = tzlocal.get_localzone().zone  # 'Europe/London'
-TIME_ZONE_DATA_SOURCE = '/usr/share/zoneinfo/'
+TIME_ZONE_DATA_SOURCE = u'/usr/share/zoneinfo/'
 
 
 class TimezoneError(Exception):

--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -5,7 +5,6 @@ from six.moves import cPickle, xrange
 import io
 import lz4
 import pymongo
-import six
 
 from arctic.store._version_store_utils import checksum, pickle_compat_load
 

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -877,9 +877,9 @@ def test_read_write_multiindex_store_keeps_timezone(library):
 
 def test_df_with_no_name(library):
     df = DataFrame(data=[1, 2, 3],
-                   index=Index(data=[dt(2016, 01, 01),
-                                     dt(2016, 01, 02),
-                                     dt(2016, 01, 03)],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
                                name='date'))
     library.write('test', df)
     ret = library.read('test').data
@@ -888,9 +888,9 @@ def test_df_with_no_name(library):
 
 def test_series_with_no_name(library):
     df = Series(data=[1, 2, 3],
-                index=Index(data=[dt(2016, 01, 01),
-                                  dt(2016, 01, 02),
-                                  dt(2016, 01, 03)],
+                index=Index(data=[dt(2016, 1, 1),
+                                  dt(2016, 1, 2),
+                                  dt(2016, 1, 3)],
                             name='date'))
     library.write('test', df)
     ret = library.read('test').data


### PR DESCRIPTION
@TomTaylorLondon indicated this has been an issue for him in the past, so I've created a fix for #113 

Because the dtype operations in the record conversions require a string for the record name, I opted to use a "magic number" (string in this case) to indicate we've converted to a string from an integer (or a None). I'm open to other methods to fix this.