### PR TITLE
Support for new chunkable Version Store type

### DIFF
--- a/arctic/__init__.py
+++ b/arctic/__init__.py
@@ -3,9 +3,10 @@
 from .arctic import Arctic, register_library_type
 from .arctic import VERSION_STORE, TICK_STORE
 from .store.version_store import register_versioned_storage
-from .store._pandas_ndarray_store import PandasDataFrameStore, PandasSeriesStore, PandasPanelStore
+from .store._pandas_ndarray_store import PandasDataFrameStore, PandasSeriesStore, PandasPanelStore, PandasDateTimeIndexedStore
 from .store._ndarray_store import NdarrayStore
 
+register_versioned_storage(PandasDateTimeIndexedStore)
 register_versioned_storage(PandasDataFrameStore)
 register_versioned_storage(PandasSeriesStore)
 register_versioned_storage(PandasPanelStore)

--- a/arctic/date/_util.py
+++ b/arctic/date/_util.py
@@ -10,7 +10,7 @@ import sys
 if sys.version_info > (3,):
     long = int
 
-    
+
 # Support standard brackets syntax for open/closed ranges.
 Ranges = {'()': OPEN_OPEN,
           '(]': OPEN_CLOSED,

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -482,7 +482,11 @@ class NdarrayStore(object):
         version['sha'] = self.checksum(item)
 
         if previous_version:
-            return
+            if version['dtype'] == str(dtype) \
+                    and version['chunk_size'] == previous_version['chunk_size'] \
+                    and 'sha' in previous_version \
+                    and self.checksum(item[:previous_version['up_to']]) == previous_version['sha']:
+                raise Exception("Append on write is handled by PandasStore")
 
         version['base_sha'] = version['sha']
         self._do_chunked_write(collection, version, symbol, records, ranges, previous_version)
@@ -539,7 +543,7 @@ class NdarrayStore(object):
         version['type'] = self.TYPE
         version['up_to'] = len(item)
         version['sha'] = self.checksum(item)
-        
+
         if previous_version:
             if version['dtype'] == str(dtype) \
                     and 'sha' in previous_version \

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -175,7 +175,7 @@ class NdarrayStore(object):
 
         start = date_range[0].strftime('%Y-%m-%d')
         end = date_range[-1].strftime('%Y-%m-%d')
-        
+
         spec = {'symbol': symbol,
                 'parent': version.get('base_version_id', version['_id']),
                 'segment': {'$lte': end, '$gte': start}
@@ -187,9 +187,10 @@ class NdarrayStore(object):
             try:
                 segments.append(decompress(x['data']) if x['compressed'] else x['data'])
             except Exception:
-                dump_bad_documents(x, collection.find_one({'_id': x['_id']}),
-                                      collection.find_one({'_id': x['_id']}),
-                                      collection.find_one({'_id': x['_id']}))
+                dump_bad_documents(x,
+                                   collection.find_one({'_id': x['_id']}),
+                                   collection.find_one({'_id': x['_id']}),
+                                   collection.find_one({'_id': x['_id']}))
                 raise
         data = b''.join(segments)
 
@@ -211,8 +212,8 @@ class NdarrayStore(object):
 
     def _do_read(self, collection, version, symbol, index_range=None):
         '''
-        index_range is a 2-tuple of integers - a [from, to) range of segments to be read. 
-            Either from or to can be None, indicating no bound. 
+        index_range is a 2-tuple of integers - a [from, to) range of segments to be read.
+            Either from or to can be None, indicating no bound.
         '''
         from_index = index_range[0] if index_range else None
         to_index = version['up_to']
@@ -268,7 +269,7 @@ class NdarrayStore(object):
 
         if not dtype:
             dtype = item.dtype
-        
+
         if previous_version['up_to'] == 0:
             dtype = dtype
         elif len(item) == 0:
@@ -340,7 +341,7 @@ class NdarrayStore(object):
                     '''If we get a duplicate key error here, this segment has the same symbol/parent/segment
                        as another chunk, but a different sha. This means that we have 'forked' history.
                        If we concat_and_rewrite here, new chunks will have a different parent id (the _id of this version doc)
-                       ...so we can safely write them. 
+                       ...so we can safely write them.
                        '''
                     self._concat_and_rewrite(collection, version, symbol, item, previous_version)
                     return

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -3,7 +3,6 @@ import hashlib
 
 from bson.binary import Binary
 import numpy as np
-import pandas as pd
 import pymongo
 from pymongo.errors import OperationFailure, DuplicateKeyError
 
@@ -178,9 +177,7 @@ class NdarrayStore(object):
                 }
 
         if date_range is not None:
-            start = date_range[0].strftime('%Y-%m-%d')
-            end = date_range[-1].strftime('%Y-%m-%d')
-            spec['segment'] = {'$lte': end, '$gte': start}
+            spec['segment'] = date_range.mongo_query()
 
         segments = []
         i = -1

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -414,8 +414,7 @@ class NdarrayStore(object):
     def chunked_write(self, arctic_lib, version, symbol, records, ranges, previous_version, dtype):
         collection = arctic_lib.get_top_level_collection()
 
-        item = np.array(records).flatten()
-
+        item = np.array([r for record in records for r in record]).flatten()
         if item.dtype.hasobject:
             raise UnhandledDtypeException()
 

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -129,6 +129,9 @@ class NdarrayStore(object):
     def can_write(self, version, symbol, data, **kwargs):
         return isinstance(data, np.ndarray) and not data.dtype.hasobject
 
+    def can_update(self, version, symbol, data, **kwargs):
+        return False
+
     def _dtype(self, string, metadata=None):
         if metadata is None:
             metadata = {}

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -6,7 +6,7 @@ import numpy as np
 import pymongo
 from pymongo.errors import OperationFailure, DuplicateKeyError
 
-from ..decorators import mongo_retry, dump_bad_documents
+from ..decorators import mongo_retry
 from ..exceptions import UnhandledDtypeException
 from ._version_store_utils import checksum
 
@@ -176,14 +176,8 @@ class NdarrayStore(object):
         segments = []
         i = -1
         for i, x in enumerate(collection.find(spec, sort=[('segment', pymongo.ASCENDING)],)):
-            try:
-                segments.append(decompress(x['data']))
-            except Exception:
-                dump_bad_documents(x,
-                                   collection.find_one({'_id': x['_id']}),
-                                   collection.find_one({'_id': x['_id']}),
-                                   collection.find_one({'_id': x['_id']}))
-                raise
+            segments.append(decompress(x['data']))
+
         data = b''.join(segments)
 
         # we can retrieve any number of segments due to how we chunk and query the chunks
@@ -228,13 +222,8 @@ class NdarrayStore(object):
         segments = []
         i = -1
         for i, x in enumerate(collection.find(spec, sort=[('segment', pymongo.ASCENDING)],)):
-            try:
-                segments.append(decompress(x['data']) if x['compressed'] else x['data'])
-            except Exception:
-                dump_bad_documents(x, collection.find_one({'_id': x['_id']}),
-                                      collection.find_one({'_id': x['_id']}),
-                                      collection.find_one({'_id': x['_id']}))
-                raise
+            segments.append(decompress(x['data']) if x['compressed'] else x['data'])
+
         data = b''.join(segments)
 
         # Check that the correct number of segments has been returned

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -4,7 +4,7 @@ import hashlib
 from bson.binary import Binary
 import numpy as np
 import pymongo
-from pymongo.errors import OperationFailure, DuplicateKeyError, BulkWriteError
+from pymongo.errors import OperationFailure, DuplicateKeyError
 
 from ..decorators import mongo_retry, dump_bad_documents
 from ..exceptions import UnhandledDtypeException
@@ -13,7 +13,6 @@ from ._version_store_utils import checksum
 from .._compression import compress_array, decompress
 from ..exceptions import ConcurrentModificationException
 from six.moves import xrange
-from itertools import chain
 
 
 logger = logging.getLogger(__name__)
@@ -464,10 +463,7 @@ class NdarrayStore(object):
                 bulk.find({'symbol': symbol, 'sha': sha, 'segment': segment['segment']}
                           ).update_one({'$addToSet': {'parent': version['_id']}})
         if seg_count != 0:
-            try:
-                bulk.execute()
-            except BulkWriteError as bwe:
-                print bwe.details
+            bulk.execute()
 
         version['segment_count'] = seg_count
         version['append_size'] = 0

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -37,39 +37,16 @@ def _promote_struct_dtypes(dtype1, dtype2):
     return np.dtype([(n, _promote(dtype1.fields[n][0], dtype2.fields.get(n, (None,))[0])) for n in dtype1.names])
 
 
-class NumpySizeChunker(object):
-    TYPE = 'numpysize'
-    def __call__(self, item, **kwargs):
-        sze = int(item.dtype.itemsize * np.prod(item.shape[1:]))
-        length = len(item)
-        chunk_size = int(_CHUNK_SIZE / sze)
-        idxs = xrange(int(np.ceil(float(length) / chunk_size)))
-        for i in idxs:
-            yield min((i + 1) * chunk_size - 1, length - 1), item[i * chunk_size: (i + 1) * chunk_size].tostring()
-
-    def index_range(self, version, from_version=None, **kwargs):
-        """
-        Tuple describing range to read from the ndarray - closed:open
-        """
-        from_index = None
-        if from_version:
-            if version['base_sha'] != from_version['base_sha']:
-                # give up - the data has been overwritten, so we can't tail this
-                raise ConcurrentModificationException("Concurrent modification - data has been overwritten")
-            from_index = from_version['up_to']
-        return from_index, None
-
-
 class NdarrayStore(object):
     """Chunked store for arbitrary ndarrays, supporting append.
-
+    
     for the simple example:
     dat = np.empty(10)
     library.write('test', dat) #version 1
     library.append('test', dat) #version 2
-
+    
     version documents:
-
+    
     [
      {u'_id': ObjectId('55fa9a7781f12654382e58b8'),
       u'symbol': u'test',
@@ -85,7 +62,7 @@ class NdarrayStore(object):
       u'sha': Binary('.........', 0),
       u'shape': [-1],
       },
-
+      
      {u'_id': ObjectId('55fa9aa981f12654382e58ba'),
       u'symbol': u'test',
       u'version': 2
@@ -100,10 +77,10 @@ class NdarrayStore(object):
       u'segment_count': 2, #2 segments included in this version
       }
       ]
-
+    
 
     segment documents:
-
+    
     [
      #first chunk written:
      {u'_id': ObjectId('55fa9a778b376a68efdd10e3'),
@@ -126,7 +103,6 @@ class NdarrayStore(object):
 
     """
     TYPE = 'ndarray'
-    chunker_mapper = {NumpySizeChunker().TYPE: NumpySizeChunker()}
 
     @classmethod
     def initialize_library(cls, *args, **kwargs):
@@ -163,6 +139,18 @@ class NdarrayStore(object):
             return np.dtype(eval(string), metadata=metadata)
         return np.dtype(string, metadata=metadata)
 
+    def _index_range(self, version, symbol, from_version=None, **kwargs):
+        """
+        Tuple describing range to read from the ndarray - closed:open
+        """
+        from_index = None
+        if from_version:
+            if version['base_sha'] != from_version['base_sha']:
+                #give up - the data has been overwritten, so we can't tail this
+                raise ConcurrentModificationException("Concurrent modification - data has been overwritten")
+            from_index = from_version['up_to']
+        return from_index, None
+
     def get_info(self, version):
         ret = {}
         dtype = self._dtype(version['dtype'], version.get('dtype_metadata', {}))
@@ -172,28 +160,33 @@ class NdarrayStore(object):
         ret['dtype'] = version['dtype']
         ret['type'] = version['type']
         ret['handler'] = self.__class__.__name__
-        ret['rows'] = int(version['rows'])
+        ret['rows'] = int(version['up_to'])
         return ret
 
-    def read(self, arctic_lib, version, symbol, read_preference=None, chunker=NumpySizeChunker(), **kwargs):
-        index_range = chunker.index_range(version, **kwargs)
+    def read(self, arctic_lib, version, symbol, read_preference=None, **kwargs):
+        index_range = self._index_range(version, symbol, **kwargs)
         collection = arctic_lib.get_top_level_collection()
         if read_preference:
             collection = collection.with_options(read_preference=read_preference)
         return self._do_read(collection, version, symbol, index_range=index_range)
 
     def _do_read(self, collection, version, symbol, index_range=None):
+        '''
+        index_range is a 2-tuple of integers - a [from, to) range of segments to be read. 
+            Either from or to can be None, indicating no bound. 
+        '''
+        from_index = index_range[0] if index_range else None
+        to_index = version['up_to']
+        if index_range and index_range[1] and index_range[1] < version['up_to']:
+            to_index = index_range[1]
         segment_count = None
 
         spec = {'symbol': symbol,
                 'parent': version.get('base_version_id', version['_id']),
-                'segment': {'$lte': version['up_to']}
+                'segment': {'$lt': to_index}
                 }
-        if index_range:
-            if index_range[0]:
-                spec['segment']['$gte'] = index_range[0]
-            if index_range[1]:
-                spec['segment']['$lte'] = index_range[1]
+        if from_index:
+            spec['segment']['$gte'] = from_index
         else:
             segment_count = version.get('segment_count', None)
 
@@ -236,7 +229,7 @@ class NdarrayStore(object):
 
         if not dtype:
             dtype = item.dtype
-
+        
         if previous_version['up_to'] == 0:
             dtype = dtype
         elif len(item) == 0:
@@ -244,32 +237,122 @@ class NdarrayStore(object):
         else:
             dtype = self._promote_types(dtype, previous_version['dtype'])
         item = item.astype(dtype)
+        if str(dtype) != previous_version['dtype']:
+            logger.debug('Converting %s from %s to %s' % (symbol, previous_version['dtype'], str(dtype)))
+            if item.dtype.hasobject:
+                raise UnhandledDtypeException()
+            version['dtype'] = str(dtype)
+            version['dtype_metadata'] = dict(dtype.metadata or {})
+            version['type'] = self.TYPE
 
-        if item.dtype.hasobject:
-            raise UnhandledDtypeException()
-        version['dtype'] = str(dtype)
-        version['dtype_metadata'] = dict(dtype.metadata or {})
-        version['type'] = self.TYPE
+            old_arr = self._do_read(collection, previous_version, symbol).astype(dtype)
+            # missing float columns should default to nan rather than zero
+            old_dtype = self._dtype(previous_version['dtype'])
+            if dtype.names is not None and old_dtype.names is not None:
+                new_columns = set(dtype.names) - set(old_dtype.names)
+                _is_float_type = lambda _dtype: _dtype.type in (np.float32, np.float64)
+                _is_void_float_type = lambda _dtype: _dtype.type == np.void and _is_float_type(_dtype.subdtype[0])
+                _is_float_or_void_float_type = lambda _dtype: _is_float_type(_dtype) or _is_void_float_type(_dtype)
+                _is_float = lambda column: _is_float_or_void_float_type(dtype.fields[column][0])
+                for new_column in filter(_is_float, new_columns):
+                    old_arr[new_column] = np.nan
 
-        old_arr = self._do_read(collection, previous_version, symbol).astype(dtype)
-        # missing float columns should default to nan rather than zero
-        old_dtype = self._dtype(previous_version['dtype'])
-        if dtype.names is not None and old_dtype.names is not None:
-            new_columns = set(dtype.names) - set(old_dtype.names)
-            _is_float_type = lambda _dtype: _dtype.type in (np.float32, np.float64)
-            _is_void_float_type = lambda _dtype: _dtype.type == np.void and _is_float_type(_dtype.subdtype[0])
-            _is_float_or_void_float_type = lambda _dtype: _is_float_type(_dtype) or _is_void_float_type(_dtype)
-            _is_float = lambda column: _is_float_or_void_float_type(dtype.fields[column][0])
-            for new_column in filter(_is_float, new_columns):
-                old_arr[new_column] = np.nan
+            item = np.concatenate([old_arr, item])
+            version['up_to'] = len(item)
+            version['sha'] = self.checksum(item)
+            version['base_sha'] = version['sha']
+            self._do_write(collection, version, symbol, item, previous_version)
+        else:
+            version['dtype'] = previous_version['dtype']
+            version['dtype_metadata'] = previous_version['dtype_metadata']
+            version['type'] = self.TYPE
+            self._do_append(collection, version, symbol, item, previous_version)
 
-        item = np.concatenate([old_arr, item])
-        version['up_to'] = previous_version['up_to']
-        version['sha'] = self.checksum(item)
-        version['base_sha'] = version['sha']
-        version['chunker'] = previous_version['chunker']
-        version['rows'] = len(item)
-        self._do_write(collection, version, symbol, item, previous_version, self.chunker_mapper[version['chunker']])
+    def _do_append(self, collection, version, symbol, item, previous_version):
+
+        data = item.tostring()
+        version['base_sha'] = previous_version['base_sha']
+        version['up_to'] = previous_version['up_to'] + len(item)
+        if len(item) > 0:
+            version['segment_count'] = previous_version['segment_count'] + 1
+            version['append_count'] = previous_version['append_count'] + 1
+            version['append_size'] = previous_version['append_size'] + len(data)
+        else:
+            version['segment_count'] = previous_version['segment_count']
+            version['append_count'] = previous_version['append_count']
+            version['append_size'] = previous_version['append_size']
+
+        #_CHUNK_SIZE is probably too big if we're only appending single rows of data - perhaps something smaller,
+        #or also look at number of appended segments?
+        if version['append_count'] < _APPEND_COUNT and version['append_size'] < _APPEND_SIZE:
+            version['base_version_id'] = previous_version.get('base_version_id', previous_version['_id'])
+
+            if len(item) > 0:
+
+                segment = {'data': Binary(data), 'compressed': False}
+                segment['segment'] = version['up_to'] - 1
+                try:
+                    collection.update_one({'symbol': symbol,
+                                           'sha': checksum(symbol, segment)},
+                                          {'$set': segment,
+                                           '$addToSet': {'parent': version['base_version_id']}},
+                                          upsert=True)
+                except DuplicateKeyError:
+                    '''If we get a duplicate key error here, this segment has the same symbol/parent/segment
+                       as another chunk, but a different sha. This means that we have 'forked' history.
+                       If we concat_and_rewrite here, new chunks will have a different parent id (the _id of this version doc)
+                       ...so we can safely write them. 
+                       '''
+                    self._concat_and_rewrite(collection, version, symbol, item, previous_version)
+                    return
+
+                if 'segment_index' in previous_version:
+                    segment_index = self._segment_index(item,
+                                                        existing_index=previous_version.get('segment_index'),
+                                                        start=previous_version['up_to'],
+                                                        new_segments=[segment['segment'], ])
+                    if segment_index:
+                        version['segment_index'] = segment_index
+                logger.debug("Appended segment %d for parent %s" % (segment['segment'], version['_id']))
+            else:
+                if 'segment_index' in previous_version:
+                    version['segment_index'] = previous_version['segment_index']
+
+        else:  # Too much data has been appended now, so rewrite (and compress/chunk).
+            self._concat_and_rewrite(collection, version, symbol, item, previous_version)
+
+    def _concat_and_rewrite(self, collection, version, symbol, item, previous_version):
+
+        version.pop('base_version_id', None)
+
+        # Figure out which is the last 'full' chunk
+        spec = {'symbol': symbol,
+                'parent': previous_version.get('base_version_id', previous_version['_id']),
+                'segment': {'$lt': version['up_to']}}
+
+        read_index_range = [0, None]
+        unchanged_segment_ids = list(collection.find(spec, projection={'_id':1, 'segment':1},
+                                                     sort=[('segment', pymongo.ASCENDING)],))\
+                                                     [:-1 * (previous_version['append_count'] + 1)]
+        if unchanged_segment_ids:
+            read_index_range[0] = unchanged_segment_ids[-1]['segment'] + 1
+
+        old_arr = self._do_read(collection, previous_version, symbol, index_range=read_index_range)
+        if len(item) == 0:
+            logger.debug('Rewrite and compress/chunk item %s, rewrote old_arr' % symbol)
+            self._do_write(collection, version, symbol, old_arr, previous_version, segment_offset=read_index_range[0])
+        elif len(old_arr) == 0:
+            logger.debug('Rewrite and compress/chunk item %s, wrote item' % symbol)
+            self._do_write(collection, version, symbol, item, previous_version, segment_offset=read_index_range[0])
+        else:
+            logger.debug("Rewrite and compress/chunk %s, np.concatenate %s to %s" % (symbol,
+                                                                                     item.dtype, old_arr.dtype))
+            self._do_write(collection, version, symbol, np.concatenate([old_arr, item]), previous_version,
+                           segment_offset=read_index_range[0])
+        if unchanged_segment_ids:
+            collection.update_many({'symbol': symbol, '_id': {'$in': [x['_id'] for x in unchanged_segment_ids]}},
+                                   {'$addToSet': {'parent': version['_id']}})
+            version['segment_count'] = version['segment_count'] + len(unchanged_segment_ids)
 
     def check_written(self, collection, symbol, version):
         # Check all the chunks are in place
@@ -289,13 +372,10 @@ class NdarrayStore(object):
         sha.update(item.tostring())
         return Binary(sha.digest())
 
-    def write(self, arctic_lib, version, symbol, item, previous_version, chunker=NumpySizeChunker(),
-              dtype=None, **kwargs):
-
+    def write(self, arctic_lib, version, symbol, item, previous_version, dtype=None):
+        collection = arctic_lib.get_top_level_collection()
         if item.dtype.hasobject:
             raise UnhandledDtypeException()
-
-        collection = arctic_lib.get_top_level_collection()
 
         if not dtype:
             dtype = item.dtype
@@ -303,23 +383,27 @@ class NdarrayStore(object):
         version['shape'] = (-1,) + item.shape[1:]
         version['dtype_metadata'] = dict(dtype.metadata or {})
         version['type'] = self.TYPE
-        version['rows'] = len(item)
-        version['up_to'] = 0
+        version['up_to'] = len(item)
         version['sha'] = self.checksum(item)
-        version['chunker'] = chunker.TYPE
-
+        
         if previous_version:
             if version['dtype'] == str(dtype) \
                     and 'sha' in previous_version \
                     and self.checksum(item[:previous_version['up_to']]) == previous_version['sha']:
                 #The first n rows are identical to the previous version, so just append.
-                self.append(collection, version, symbol, item[previous_version['up_to']:], previous_version)
+                self._do_append(collection, version, symbol, item[previous_version['up_to']:], previous_version)
                 return
 
         version['base_sha'] = version['sha']
-        self._do_write(collection, version, symbol, item, previous_version, chunker, **kwargs)
+        self._do_write(collection, version, symbol, item, previous_version)
 
-    def _do_write(self, collection, version, symbol, item, previous_version, chunker, **kwargs):
+    def _do_write(self, collection, version, symbol, item, previous_version, segment_offset=0):
+
+        sze = int(item.dtype.itemsize * np.prod(item.shape[1:]))
+
+        # chunk and store the data by (uncompressed) size
+        chunk_size = int(_CHUNK_SIZE / sze)
+
         previous_shas = []
         if previous_version:
             previous_shas = set([x['sha'] for x in
@@ -328,21 +412,27 @@ class NdarrayStore(object):
                                                  )
                                  ])
 
+        length = len(item)
+
+        if segment_offset > 0 and 'segment_index' in previous_version:
+            existing_index = previous_version['segment_index']
+        else:
+            existing_index = None
+
+        segment_index = []
         i = -1
-        chunks = []
-        chunk_ranges = []
-        for rng, chunk in chunker(item, **kwargs):
-            chunks.append(chunk)
-            chunk_ranges.append(rng)
+
+        # Compress
+        idxs = xrange(int(np.ceil(float(length) / chunk_size)))
+        chunks = [(item[i * chunk_size: (i + 1) * chunk_size]).tostring() for i in idxs]
         compressed_chunks = compress_array(chunks)
 
         # Write
         bulk = collection.initialize_unordered_bulk_op()
-        rng = 0
-        for rng, chunk in zip(chunk_ranges, compressed_chunks):
-            i += 1
+        for i, chunk in zip(idxs, compressed_chunks):
             segment = {'data': Binary(chunk), 'compressed': True}
-            segment['segment'] = rng
+            segment['segment'] = min((i + 1) * chunk_size - 1, length - 1) + segment_offset
+            segment_index.append(segment['segment'])
             sha = checksum(symbol, segment)
             if sha not in previous_shas:
                 segment['sha'] = sha
@@ -351,13 +441,35 @@ class NdarrayStore(object):
             else:
                 bulk.find({'symbol': symbol, 'sha': sha, 'segment': segment['segment']}
                           ).update_one({'$addToSet': {'parent': version['_id']}})
-        # update up_to with the end of the range value from chunker
-        version['up_to'] = rng
         if i != -1:
             bulk.execute()
 
+        segment_index = self._segment_index(item, existing_index=existing_index, start=segment_offset,
+                                            new_segments=segment_index)
+        if segment_index:
+            version['segment_index'] = segment_index
         version['segment_count'] = i + 1
         version['append_size'] = 0
         version['append_count'] = 0
 
         self.check_written(collection, symbol, version)
+
+    def _segment_index(self, new_data, existing_index, start, new_segments):
+        """
+        Generate a segment index which can be used in subselect data in _index_range.
+        This function must handle both generation of the index and appending to an existing index
+
+        Parameters:
+        -----------
+        new_data: new data being written (or appended)
+        existing_index: index field from the versions document of the previous version
+        start: first (0-based) offset of the new data
+        segments: list of offsets. Each offset is the row index of the
+                  the last row of a particular chunk relative to the start of the _original_ item.
+                  array(new_data) - segments = array(offsets in item)
+        
+        Returns:
+        --------
+        Library specific index metadata to be stored in the version document.
+        """
+        pass  # numpy arrays have no index

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -451,8 +451,9 @@ class NdarrayStore(object):
         collection = arctic_lib.get_top_level_collection()
 
         item = np.array([r for record in records for r in record]).flatten()
-        if item.dtype.hasobject:
-            raise UnhandledDtypeException()
+        for record in records:
+            if record.dtype.hasobject:
+                raise UnhandledDtypeException()
 
         version['dtype'] = str(dtype)
         version['shape'] = (-1,) + item.shape[1:]

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -379,7 +379,8 @@ class PandasDateTimeIndexedStore(PandasStore):
 
     def get_range(self, df):
         dates = df.reset_index()['date']
-        return dates.min().strftime('%Y-%m-%d'), dates.max().strftime('%Y-%m-%d')
+        # return dates.min().strftime('%Y-%m-%d'), dates.max().strftime('%Y-%m-%d')
+        return dates.min(), dates.max()
 
     def to_records(self, df, chunk_size):
         """
@@ -432,7 +433,7 @@ class PandasDateTimeIndexedStore(PandasStore):
 
         if date_range is None:
             return df
-        return df.ix[date_range[0]:date_range[-1]]
+        return df.ix[date_range[0]:date_range[1]]
 
     def append(self, arctic_lib, version, symbol, item, previous_version):
         if isinstance(item, Series) and previous_version['pandas_type'] == 'df':

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -490,6 +490,8 @@ class PandasDateTimeIndexedStore(PandasStore):
             # assuming they exist, update them and store the original chunk range for
             # later use
             if not df.empty:
+                if df.equals(record):
+                    continue
                 record = record.combine_first(df)
                 orig_ranges.append((self.get_range(df)))
             else:
@@ -499,9 +501,10 @@ class PandasDateTimeIndexedStore(PandasStore):
             records.append(r)
             ranges.append((start, end))
 
-        super(PandasDateTimeIndexedStore, self).chunked_update(arctic_lib,
-                                                               version,
-                                                               symbol,
-                                                               records,
-                                                               ranges,
-                                                               orig_ranges)
+        if len(records) > 0:
+            super(PandasDateTimeIndexedStore, self).chunked_update(arctic_lib,
+                                                                   version,
+                                                                   symbol,
+                                                                   records,
+                                                                   ranges,
+                                                                   orig_ranges)

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -352,19 +352,22 @@ class PandasDateTimeIndexedStore(PandasStore):
     TYPE = 'pandasdti'
 
     def _column_data(self, df):
-        columns = list(map(str, df.columns))
-        column_vals = [df[c].values for c in df.columns]
-        return columns, column_vals
+        if isinstance(df, DataFrame):
+            return PandasDataFrameStore()._column_data(df)
+        else:
+            return PandasSeriesStore()._column_data(df)
 
     def can_write(self, version, symbol, data, **kwargs):
         if isinstance(data, (DataFrame, Series)):
             if 'date' in data.index.names and 'chunk_size' in version and version['chunk_size'] in ('D', 'M', 'Y'):
-                if np.any(data.dtypes.values == 'object'):
+                if isinstance(data, DataFrame) and np.any(data.dtypes.values == 'object'):
+                    return self.can_convert_to_records_without_objects(data, symbol)
+                elif isinstance(data, Series) and (data.dtype == np.object_ or data.index.dtype == np.object_):
                     return self.can_convert_to_records_without_objects(data, symbol)
                 return True
         return False
 
-    def get_key_for_date(self, date, chunk_size):
+    def get_date_chunk(self, date, chunk_size):
         fmt = ""
         if chunk_size == 'Y':
             fmt = '%Y'
@@ -374,39 +377,40 @@ class PandasDateTimeIndexedStore(PandasStore):
             fmt = '%Y-%m-%d'
         return date.strftime(fmt)
 
+    def get_range(self, df):
+        dates = df.reset_index()['date']
+        return dates.min().strftime('%Y-%m-%d'), dates.max().strftime('%Y-%m-%d')
+
     def to_records(self, df, chunk_size):
         """
-        chunks the dataframe by dates
+        chunks the dataframe/series by dates
 
         returns
         -------
-        A list of dataframes
+        A list of tuples - (date, dataframe/series)
         """
-        dates = [pd.to_datetime(d) for d in df.date.unique()]
-        key_map = {d: self.get_key_for_date(d, chunk_size) for d in dates}
-        return [g for g in df.groupby(df.date.map(key_map))]
 
-    def from_records(self, recarr):
-        index = self._index_from_records(recarr)
-        column_fields = [x for x in recarr.dtype.names if x not in recarr.dtype.metadata['index']]
-        if len(recarr) == 0:
-            rdata = recarr[column_fields] if len(column_fields) > 0 else None
-            return DataFrame(rdata, index=index)
-
-        columns = recarr.dtype.metadata['columns']
-        return DataFrame(data=recarr[column_fields], index=index, columns=columns)
+        dates = [pd.to_datetime(d) for d in df.index.get_level_values('date').drop_duplicates()]
+        key_array = [self.get_date_chunk(d, chunk_size) for d in dates]
+        for g in df.groupby(key_array):
+            start, end = self.get_range(g[1])
+            yield start, end, g[1]
 
     def write(self, arctic_lib, version, symbol, item, previous_version, chunk_size=None):
-        index = item.index.names
-        item = item.reset_index()
-        recs = self.to_records(item, chunk_size)
+        if isinstance(item, Series):
+            version['pandas_type'] = 'series'
+        else:
+            version['pandas_type'] = 'df'
+
         records = []
         ranges = []
         dtype = None
-        for record in recs:
-            r, dtype = super(PandasDateTimeIndexedStore, self).to_records(record[1].set_index(index))
+
+        for start, end, record in self.to_records(item, chunk_size):
+            r, dtype = super(PandasDateTimeIndexedStore, self).to_records(record)
             records.append(r)
-            ranges.append((record[0], record[0]))
+            ranges.append((start, end))
+
         super(PandasDateTimeIndexedStore, self).chunked_write(arctic_lib,
                                                               version,
                                                               symbol,
@@ -420,7 +424,10 @@ class PandasDateTimeIndexedStore(PandasStore):
                                                                     version,
                                                                     symbol,
                                                                     date_range)
-        return self.from_records(item)
+
+        if version['pandas_type'] == 'series':
+            return PandasSeriesStore().from_records(item)
+        return PandasDataFrameStore().from_records(item)
 
     def append(self, arctic_lib, version, symbol, item, previous_version):
         pass

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -426,8 +426,13 @@ class PandasDateTimeIndexedStore(PandasStore):
                                                                     date_range)
 
         if version['pandas_type'] == 'series':
-            return PandasSeriesStore().from_records(item).ix[date_range[0]:date_range[-1]]
-        return PandasDataFrameStore().from_records(item).ix[date_range[0]:date_range[-1]]
+            df = PandasSeriesStore().from_records(item)
+        else:
+            df = PandasDataFrameStore().from_records(item)
+
+        if date_range is None:
+            return df
+        return df.ix[date_range[0]:date_range[-1]]
 
     def append(self, arctic_lib, version, symbol, item, previous_version):
         if isinstance(item, Series) and previous_version['pandas_type'] == 'df':

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -228,9 +228,6 @@ class PandasStore(NdarrayStore):
         ret['dtype'] = ast.literal_eval(version['dtype'])
         return ret
 
-    def can_update(self, version, symbol, data, **kwargs):
-        return False
-
 
 def _start_end(date_range, dts):
     """
@@ -466,20 +463,20 @@ class PandasDateTimeIndexedStore(PandasStore):
             records.append(r)
             ranges.append((start, end))
 
-        super(PandasDateTimeIndexedStore, self).chunked_write(arctic_lib,
-                                                              version,
-                                                              symbol,
-                                                              records,
-                                                              ranges,
-                                                              previous_version,
-                                                              dtype)
+        super(PandasDateTimeIndexedStore, self)._chunked_write(arctic_lib,
+                                                               version,
+                                                               symbol,
+                                                               records,
+                                                               ranges,
+                                                               previous_version,
+                                                               dtype)
 
     def read(self, arctic_lib, version, symbol, date_range=None, **kwargs):
 
-        item = super(PandasDateTimeIndexedStore, self).chunked_read(arctic_lib,
-                                                                    version,
-                                                                    symbol,
-                                                                    date_range)
+        item = super(PandasDateTimeIndexedStore, self)._chunked_read(arctic_lib,
+                                                                     version,
+                                                                     symbol,
+                                                                     date_range)
 
         if version['pandas_type'] == 'series':
             df = PandasSeriesStore().from_records(item)
@@ -530,20 +527,20 @@ class PandasDateTimeIndexedStore(PandasStore):
 
         # update old chunks before writing new ones
         if len(update_records) > 0:
-            super(PandasDateTimeIndexedStore, self).chunked_update(arctic_lib,
-                                                                   version,
-                                                                   symbol,
-                                                                   update_records,
-                                                                   update_ranges,
-                                                                   update_orig_ranges)
+            super(PandasDateTimeIndexedStore, self)._chunked_update(arctic_lib,
+                                                                    version,
+                                                                    symbol,
+                                                                    update_records,
+                                                                    update_ranges,
+                                                                    update_orig_ranges)
 
-        super(PandasDateTimeIndexedStore, self).chunked_append(arctic_lib,
-                                                               version,
-                                                               symbol,
-                                                               records,
-                                                               ranges,
-                                                               previous_version,
-                                                               dtype)
+        super(PandasDateTimeIndexedStore, self)._chunked_append(arctic_lib,
+                                                                version,
+                                                                symbol,
+                                                                records,
+                                                                ranges,
+                                                                previous_version,
+                                                                dtype)
 
     def update(self, arctic_lib, version, symbol, item):
         records = []
@@ -567,9 +564,9 @@ class PandasDateTimeIndexedStore(PandasStore):
             ranges.append((start, end))
 
         if len(records) > 0:
-            super(PandasDateTimeIndexedStore, self).chunked_update(arctic_lib,
-                                                                   version,
-                                                                   symbol,
-                                                                   records,
-                                                                   ranges,
-                                                                   orig_ranges)
+            super(PandasDateTimeIndexedStore, self)._chunked_update(arctic_lib,
+                                                                    version,
+                                                                    symbol,
+                                                                    records,
+                                                                    ranges,
+                                                                    orig_ranges)

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -26,7 +26,7 @@ def _to_primitive(arr, string_max_len=None):
             if isinstance(arr[0], Timestamp):
                 return np.array([t.value for t in arr], dtype=DTN64_DTYPE)
         if string_max_len:
-            return np.array(arr.astype('S{:d}'.format(string_max_len)))
+            return np.array(arr.astype('U{:d}'.format(string_max_len)))
         return np.array(list(arr))
     return arr
 

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -7,6 +7,7 @@ from pandas.tseries.index import DatetimeIndex
 from pandas.tslib import Timestamp, get_timezone
 
 import numpy as np
+import pandas as pd
 
 from .._compression import compress, decompress
 from ..date._util import to_pandas_closed_closed
@@ -28,6 +29,40 @@ def _to_primitive(arr):
                 return np.array([t.value for t in arr], dtype=DTN64_DTYPE)
         return np.array(list(arr))
     return arr
+
+
+class PandasDateChunker(object):
+    TYPE = 'pandasdate'
+
+    def __call__(self, item, **kwargs):
+        if 'chunk' not in kwargs or kwargs['chunk'] not in ('D', 'M', 'Y'):
+            raise Exception('Must specify a chunk size of D, M or Y when using a date chunker')
+
+        if 'dates' in item:
+            dates = [pd.to_datetime(d) for d in item.date.unique()]
+        else:
+            try:
+                dates = [pd.to_datetime(d) for d in item.get_level_values('date').unique()]
+            except:
+                raise Exception('Dataframe/Series must be date indexed')
+        key_map = {d: self.get_key_for_date(d) for d in dates}
+
+        if 'dates' in item:
+            g = item.groupby(item.date.map(key_map))
+        else:
+            g = item.groupby(item.get_level_values('date').map(key_map))
+
+        for group in g:
+            yield str(g.date.max()), PandasStore().to_records(group)[0]
+
+    def index_range(self, version, from_version=None, **kwargs):
+        from_index = None
+        if from_version:
+            if version['base_sha'] != from_version['base_sha']:
+                # give up - the data has been overwritten, so we can't tail this
+                raise ConcurrentModificationException("Concurrent modification - data has been overwritten")
+            from_index = from_version['up_to']
+        return from_index, None
 
 
 class PandasStore(NdarrayStore):
@@ -107,7 +142,7 @@ class PandasStore(NdarrayStore):
     def can_convert_to_records_without_objects(self, df, symbol):
         # We can't easily distinguish string columns from objects
         try:
-            arr,_ = self.to_records(df)
+            arr, _ = self.to_records(df)
         except Exception as e:
             # This exception will also occur when we try to write the object so we fall-back to saving using Pickle
             log.info('Pandas dataframe %s caused exception "%s" when attempting to convert to records. Saving as Blob.'
@@ -124,88 +159,9 @@ class PandasStore(NdarrayStore):
             else:
                 return True
 
-    def _segment_index(self, recarr, existing_index, start, new_segments):
-        """
-        Generate index of datetime64 -> item offset.
-
-        Parameters:
-        -----------
-        new_data: new data being written (or appended)
-        existing_index: index field from the versions document of the previous version
-        start: first (0-based) offset of the new data
-        segments: list of offsets. Each offset is the row index of the
-                  the last row of a particular chunk relative to the start of the _original_ item.
-                  array(new_data) - segments = array(offsets in item)
-
-        Returns:
-        --------
-        Binary(compress(array([(index, datetime)]))
-            Where index is the 0-based index of the datetime in the DataFrame
-        """
-        # find the index of the first datetime64 column
-        idx_col = self._datetime64_index(recarr)
-        # if one exists let's create the index on it
-        if idx_col is not None:
-            new_segments = np.array(new_segments, dtype='i8')
-            last_rows = recarr[new_segments - start]
-            # create numpy index
-            index = np.core.records.fromarrays([last_rows[idx_col]]
-                                               + [new_segments, ],
-                                               dtype=INDEX_DTYPE)
-            # append to existing index if exists
-            if existing_index:
-                existing_index_arr = np.fromstring(decompress(existing_index), dtype=INDEX_DTYPE)
-                if start > 0:
-                    existing_index_arr = existing_index_arr[existing_index_arr['index'] < start]
-                index = np.concatenate((existing_index_arr, index))
-            return Binary(compress(index.tostring()))
-        elif existing_index:
-            raise ArcticException("Could not find datetime64 index in item but existing data contains one")
-        return None
-
-    def _datetime64_index(self, recarr):
-        """ Given a np.recarray find the first datetime64 column """
-        # TODO: Handle multi-indexes
-        names = recarr.dtype.names
-        for name in names:
-            if recarr[name].dtype == DTN64_DTYPE:
-                return name
-        return None
-
-    def _index_range(self, version, symbol, date_range=None, **kwargs):
-        """ Given a version, read the segment_index and return the chunks associated
-        with the date_range. As the segment index is (id -> last datetime)
-        we need to take care in choosing the correct chunks. """
-        if date_range and 'segment_index' in version:
-            index = np.fromstring(decompress(version['segment_index']), dtype=INDEX_DTYPE)
-            dtcol = self._datetime64_index(index)
-            if dtcol and len(index):
-                dts = index[dtcol]
-                start, end = _start_end(date_range, dts)
-                if start > dts[-1]:
-                    return -1, -1
-                idxstart = min(np.searchsorted(dts, start), len(dts) - 1)
-                idxend = min(np.searchsorted(dts, end), len(dts) - 1)
-                return int(index['index'][idxstart]), int(index['index'][idxend] + 1)
-        return super(PandasStore, self)._index_range(version, symbol, **kwargs)
-
-    def _daterange(self, recarr, date_range):
-        """ Given a recarr, slice out the given artic.date.DateRange if a
-        datetime64 index exists """
-        idx = self._datetime64_index(recarr)
-        if idx and len(recarr):
-            dts = recarr[idx]
-            mask = Series(np.zeros(len(dts)), index=dts)
-            start, end = _start_end(date_range, dts)
-            mask[start:end] = 1.0
-            return recarr[mask.values.astype(bool)]
-        return recarr
-
     def read(self, arctic_lib, version, symbol, read_preference=None, date_range=None, **kwargs):
         item = super(PandasStore, self).read(arctic_lib, version, symbol, read_preference,
                                              date_range=date_range, **kwargs)
-        if date_range:
-            item = self._daterange(item, date_range)
         return item
 
     def get_info(self, version):
@@ -218,20 +174,6 @@ class PandasStore(NdarrayStore):
         ret['handler'] = self.__class__.__name__
         ret['dtype'] = ast.literal_eval(version['dtype'])
         return ret
-
-
-def _start_end(date_range, dts):
-    """
-    Return tuple: [start, end] of np.datetime64 dates that are inclusive of the passed
-    in datetimes.
-    """
-    # FIXME: timezones
-    assert len(dts)
-    _assert_no_timezone(date_range)
-    date_range = to_pandas_closed_closed(date_range, add_tz=False)
-    start = np.datetime64(date_range.start) if date_range.start else dts[0]
-    end = np.datetime64(date_range.end) if date_range.end else dts[-1]
-    return start, end
 
 
 def _assert_no_timezone(date_range):
@@ -261,8 +203,8 @@ class PandasSeriesStore(PandasStore):
         return False
 
     def write(self, arctic_lib, version, symbol, item, previous_version):
-        item, md = self.to_records(item)
-        super(PandasSeriesStore, self).write(arctic_lib, version, symbol, item, previous_version, dtype=md)
+        _, md = self.to_records(item)
+        super(PandasSeriesStore, self).write(arctic_lib, version, symbol, item, previous_version, chunker=PandasDateChunker(), dtype=md)
 
     def append(self, arctic_lib, version, symbol, item, previous_version):
         item, md = self.to_records(item)
@@ -299,8 +241,8 @@ class PandasDataFrameStore(PandasStore):
         return False
 
     def write(self, arctic_lib, version, symbol, item, previous_version):
-        item, md = self.to_records(item)
-        super(PandasDataFrameStore, self).write(arctic_lib, version, symbol, item, previous_version, dtype=md)
+        _, md = self.to_records(item)
+        super(PandasDataFrameStore, self).write(arctic_lib, version, symbol, item, previous_version, chunker=PandasDateChunker(), dtype=md)
 
     def append(self, arctic_lib, version, symbol, item, previous_version):
         item, md = self.to_records(item)

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -100,7 +100,6 @@ class PandasStore(NdarrayStore):
         # For some reason the dtype metadata is lost in the line above
         # and setting rtn.dtype to dtype does not preserve the metadata
         # see https://github.com/numpy/numpy/issues/6771
-
         return (rtn, dtype)
 
     def can_convert_to_records_without_objects(self, df, symbol, func=None):

--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -5,7 +5,6 @@ from six.moves import cPickle, xrange
 import io
 import lz4
 import pymongo
-import six
 
 from arctic.store._version_store_utils import checksum, pickle_compat_load
 
@@ -41,7 +40,7 @@ class PickleStore(object):
             return pickle_compat_load(io.BytesIO(data))
         return version['data']
 
-    def write(self, arctic_lib, version, symbol, item, previous_version):
+    def write(self, arctic_lib, version, symbol, item, previous_version, **kwargs):
         try:
             # If it's encodeable, then ship it
             b = bson.BSON.encode({'data': item})

--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -7,13 +7,15 @@ import lz4
 import pymongo
 
 from arctic.store._version_store_utils import checksum, pickle_compat_load
+from ._store import BaseStore
+
 
 _MAGIC_CHUNKED = '__chunked__'
 _CHUNK_SIZE = 15 * 1024 * 1024  # 15MB
 _MAX_BSON_ENCODE = 256 * 1024  # 256K - don't fill up the version document with encoded bson
 
 
-class PickleStore(object):
+class PickleStore(BaseStore):
 
     @classmethod
     def initialize_library(cls, *args, **kwargs):

--- a/arctic/store/_store.py
+++ b/arctic/store/_store.py
@@ -1,0 +1,12 @@
+class BaseStore(object):
+    def can_delete(self, version, symbol):
+        pass
+
+    def can_read(self, version, symbol):
+        pass
+
+    def can_write(self, version, symbol, data, **kwargs):
+        pass
+
+    def can_update(self, version, symbol, data, **kwargs):
+        pass

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -563,7 +563,7 @@ class VersionStore(object):
             version['chunk_size'] = kwargs['chunk_size']
 
         handler = self._write_handler(version, symbol, data, **kwargs)
-
+        print handler
         mongo_retry(handler.write)(self._arctic_lib, version, symbol, data, previous_version, **kwargs)
 
         # Insert the new version into the version DB

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -563,7 +563,6 @@ class VersionStore(object):
             version['chunk_size'] = kwargs['chunk_size']
 
         handler = self._write_handler(version, symbol, data, **kwargs)
-        print handler
         mongo_retry(handler.write)(self._arctic_lib, version, symbol, data, previous_version, **kwargs)
 
         # Insert the new version into the version DB

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -526,7 +526,8 @@ class VersionStore(object):
     def update(self, symbol, data, **kwargs):
         """
         Find an existing chunk of data and update (overwrite) it. This WILL NOT
-        create a new version of the data!
+        create a new version of the data! This is currently only supported by the
+        PandasDatetimeIndexedStore storage type.
 
         Parameters
         ----------

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -559,6 +559,9 @@ class VersionStore(object):
                                                   sort=[('version', pymongo.DESCENDING)],
                                                   )
 
+        if 'chunk_size' in  kwargs:
+            version['chunk_size'] = kwargs['chunk_size']
+
         handler = self._write_handler(version, symbol, data, **kwargs)
         mongo_retry(handler.write)(self._arctic_lib, version, symbol, data, previous_version, **kwargs)
 

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -1,5 +1,4 @@
 from datetime import datetime as dt, timedelta
-import pprint
 import logging
 
 import bson
@@ -288,6 +287,14 @@ class VersionStore(object):
             handler = self._bson_handler
         return handler
 
+    def _update_handler(self, version, symbol, data, **kwargs):
+        handler = None
+        for h in _TYPE_HANDLERS:
+            if h.can_update(version, symbol, data, **kwargs):
+                handler = h
+                break
+        return handler
+
     def read(self, symbol, as_of=None, date_range=None, from_version=None, allow_secondary=None, **kwargs):
         """
         Read data for the named symbol.  Returns a VersionedItem object with
@@ -359,8 +366,6 @@ class VersionStore(object):
         if handler and hasattr(handler, 'get_info'):
             return handler.get_info(version)
         return {}
-
-
 
     def _do_read(self, symbol, version, from_version=None, **kwargs):
         handler = self._read_handler(version, symbol)
@@ -517,6 +522,30 @@ class VersionStore(object):
         return VersionedItem(symbol=symbol, library=self._arctic_lib.get_name(), version=version['version'],
                              metadata=version.pop('metadata', None), data=None)
 
+    @mongo_retry
+    def update(self, symbol, data, **kwargs):
+        """
+        Find an existing chunk of data and update (overwrite) it. This WILL NOT
+        create a new version of the data!
+
+        Parameters
+        ----------
+        symbol : `str`
+            symbol name for the item
+        data :
+            to be persisted
+        """
+        version = self._read_metadata(symbol)
+        old_ver = dict(version)
+        handler = self._update_handler(version, symbol, data, **kwargs)
+
+        if handler is None:
+            Exception("Update not implemented for handler %s" % handler)
+
+        mongo_retry(handler.update)(self._arctic_lib, version, symbol, data, **kwargs)
+        mongo_retry(self._versions.delete_one)(old_ver)
+        mongo_retry(self._versions.insert_one)(version)
+
     def _publish_change(self, symbol, version):
         if self._publish_changes:
             mongo_retry(self._changes.insert_one)(version)
@@ -540,7 +569,7 @@ class VersionStore(object):
             Default: True
         kwargs :
             passed through to the write handler
-            
+
         Returns
         -------
         VersionedItem named tuple containing the metadata and verison number

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -563,6 +563,7 @@ class VersionStore(object):
             version['chunk_size'] = kwargs['chunk_size']
 
         handler = self._write_handler(version, symbol, data, **kwargs)
+
         mongo_retry(handler.write)(self._arctic_lib, version, symbol, data, previous_version, **kwargs)
 
         # Insert the new version into the version DB

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ compress = Extension('arctic._compress',
 
 setup(
     name="arctic",
-    version="1.21.0",
+    version="1.22.0",
     author="Man AHL Technology",
     author_email="ManAHLTech@ahl.com",
     description=("AHL Research Versioned TimeSeries and Tick store"),

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -888,7 +888,6 @@ def test_pandas_datetime_index_store_df(library):
 
     library.write('dti_test', df, chunk_size='D')
     ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
-
     assert_frame_equal(df, ret)
 
 
@@ -902,3 +901,37 @@ def test_pandas_datetime_index_store_series(library):
     library.write('dti_test', df, chunk_size='D')
     s = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_series_equal(s, df)
+
+
+def test_pandas_dti_monthly_df(library):
+    df = DataFrame(data=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3),
+                                     dt(2016, 1, 4),
+                                     dt(2016, 1, 5),
+                                     dt(2016, 2, 1),
+                                     dt(2016, 2, 2),
+                                     dt(2016, 2, 3),
+                                     dt(2016, 2, 4),
+                                     dt(2016, 3, 1)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='M')
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 1))).data
+    assert len(ret) == 5
+    assert_frame_equal(df, library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2017, 1, 1))).data)
+
+
+def test_pandas_dti_yearly_df(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 2, 1),
+                                     dt(2016, 3, 3)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='Y')
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 1))).data
+    assert_frame_equal(df, ret)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -895,7 +895,7 @@ def test_pandas_datetime_index_store_df(library):
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='D')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_frame_equal(df, ret)
 
 
@@ -912,6 +912,32 @@ def test_pandas_dti_no_range(library):
     assert_frame_equal(df, ret)
 
 
+def test_pandas_dti_closed_open(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='D')
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), None)).data
+    assert_frame_equal(df, ret)
+
+
+def test_pandas_dti_open_closed(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='D')
+    ret = library.read('dti_test', date_range=DateRange(None, dt(2017, 1, 1))).data
+    assert_frame_equal(df, ret)
+
+
 def test_pandas_datetime_index_store_series(library):
     df = Series(data=[1, 2, 3],
                 index=Index(data=[dt(2016, 1, 1),
@@ -920,7 +946,7 @@ def test_pandas_datetime_index_store_series(library):
                             name='date'),
                 name='data')
     library.write('dti_test', df, chunk_size='D')
-    s = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
+    s = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_series_equal(s, df)
 
 
@@ -940,7 +966,7 @@ def test_pandas_dti_monthly_df(library):
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='M')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 2))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 2))).data
     assert len(ret) == 2
     # assert_frame_equal(df, library.read('dti_test').data)
 
@@ -954,7 +980,7 @@ def test_pandas_dti_yearly_df(library):
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='Y')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 3, 3))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 3, 3))).data
     assert_frame_equal(df, ret)
 
 
@@ -967,7 +993,7 @@ def test_pandas_dti_yearly_series(library):
                 name='data')
 
     library.write('dti_test', df, chunk_size='Y')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 3, 3))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 3, 3))).data
     assert_series_equal(df, ret)
 
 
@@ -987,7 +1013,7 @@ def test_pandas_dti_append_daily(library):
                                 name='date'),
                     columns=['data'])
     library.append('dti_test', df2)
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 6))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 6))).data
     assert_frame_equal(ret, pd.concat([df, df2]))
 
 
@@ -1007,7 +1033,7 @@ def test_pandas_dti_append_monthly(library):
                                 name='date'),
                     columns=['data'])
     library.append('dti_test', df2)
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 12, 31))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 12, 31))).data
     assert_frame_equal(ret, pd.concat([df, df2]))
 
 
@@ -1027,7 +1053,7 @@ def test_pandas_dti_append_yearly(library):
                                 name='date'),
                     columns=['data'])
     library.append('dti_test', df2)
-    ret = library.read('dti_test', date_range=date_range(dt(2000, 1, 1), dt(2100, 12, 31))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2000, 1, 1), dt(2100, 12, 31))).data
     assert_frame_equal(ret, pd.concat([df, df2]))
 
 
@@ -1047,7 +1073,7 @@ def test_pandas_dti_append_existing_chunk(library):
                                 name='date'),
                     columns=['data'])
     library.append('dti_test', df2)
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 31))).data
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 31))).data
     assert_frame_equal(ret, pd.concat([df, df2]))
 
 

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -875,3 +875,12 @@ def test_read_write_multiindex_store_keeps_timezone(library):
     assert list(library.read('spam').data.index[0]) == row0[:-1]
     assert list(library.read('spam').data.index[1]) == row1[:-1]
 
+def test_pandas_datetime_index_store(library):
+    df = DataFrame({'date':[dt(2016, 01, 01), dt(2016, 01, 02), dt(2016, 01, 03)], 'data':[1, 2, 3]})
+    df = df.set_index('date')
+    library.write('dti_test', df, chunk_size='D')
+    df = library.read('dti_test', date_range=date_range(dt(2016, 01, 02), dt(2016, 01, 02))).data
+    print df
+
+
+

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -919,9 +919,9 @@ def test_pandas_dti_monthly_df(library):
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='M')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 1))).data
-    assert len(ret) == 5
-    assert_frame_equal(df, library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2017, 1, 1))).data)
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 2))).data
+    assert len(ret) == 2
+    # assert_frame_equal(df, library.read('dti_test').data)
 
 
 def test_pandas_dti_yearly_df(library):
@@ -1028,4 +1028,3 @@ def test_pandas_dti_append_existing_chunk(library):
     library.append('dti_test', df2)
     ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 31))).data
     assert_frame_equal(ret, pd.concat([df, df2]))
-

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1136,3 +1136,23 @@ def test_pandas_dti_store_objects_series(library):
     library.write('dti_test', df, chunk_size='D')
     ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_series_equal(df, ret)
+
+
+def test_pandas_dti_write_with_append(library):
+    df = DataFrame(data={'data': [1], 'values': [10]},
+                   index=Index(data=[dt(2016, 1, 1)], name='date'))
+    library.write('dti_test', df, chunk_size='M')
+    df2 = DataFrame(data={'data': [1, 2], 'values': [10, 20]},
+                    index=Index(data=[dt(2016, 1, 1), dt(2016, 1, 2)], name='date'))
+    library.write('dti_test', df2, chunk_size='M')
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
+    assert_frame_equal(df2, ret)
+
+
+def test_pandas_dti_write_with_append_series(library):
+    df = Series(data=[1], index=Index(data=[dt(2016, 1, 1)], name='date'), name='data')
+    library.write('dti_test', df, chunk_size='M')
+    df2 = Series(data=[1, 2], index=Index(data=[dt(2016, 1, 1), dt(2016, 1, 2)], name='date'), name='data')
+    library.write('dti_test', df2, chunk_size='M')
+    ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
+    assert_series_equal(df2, ret)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -880,25 +880,25 @@ def test_read_write_multiindex_store_keeps_timezone(library):
 
 def test_pandas_datetime_index_store_df(library):
     df = DataFrame(data=[1, 2, 3],
-                   index=Index(data=[dt(2016, 01, 01),
-                                     dt(2016, 01, 02),
-                                     dt(2016, 01, 03)],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
                                name='date'),
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='D')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 01, 01), dt(2016, 01, 03))).data
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
 
     assert_frame_equal(df, ret)
 
 
 def test_pandas_datetime_index_store_series(library):
     df = Series(data=[1, 2, 3],
-                index=Index(data=[dt(2016, 01, 01),
-                                  dt(2016, 01, 02),
-                                  dt(2016, 01, 03)],
+                index=Index(data=[dt(2016, 1, 1),
+                                  dt(2016, 1, 2),
+                                  dt(2016, 1, 3)],
                             name='date'),
                 name='data')
     library.write('dti_test', df, chunk_size='D')
-    s = library.read('dti_test', date_range=date_range(dt(2016, 01, 01), dt(2016, 01, 03))).data
+    s = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_series_equal(s, df)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1315,20 +1315,20 @@ def test_pandas_dti_with_strings(library):
 def test_pandas_dti_with_strings_multiindex_append(library):
     df = DataFrame(data={'data': ['A', 'BBB', 'CC']},
                    index=MultiIndex.from_tuples([(dt(2016, 1, 1), 2),
-                                                 (dt(2016, 1, 2), 3),
-                                                 (dt(2016, 1, 3), 2)],
+                                                 (dt(2016, 1, 1), 3),
+                                                 (dt(2016, 1, 2), 2)],
                                                 names=['date', 'security']))
     library.write('dti_test', df, chunk_size='D')
     read_df = library.read('dti_test').data
     assert_frame_equal(read_df, df)
     df2 = DataFrame(data={'data': ['AAAAAAA']},
-                    index=MultiIndex.from_tuples([(dt(2016, 1, 4), 4)],
+                    index=MultiIndex.from_tuples([(dt(2016, 1, 2), 4)],
                                                  names=['date', 'security']))
     library.append('dti_test', df2)
     df = DataFrame(data={'data': ['A', 'BBB', 'CC', 'AAAAAAA']},
                    index=MultiIndex.from_tuples([(dt(2016, 1, 1), 2),
-                                                 (dt(2016, 1, 2), 3),
-                                                 (dt(2016, 1, 3), 2),
-                                                 (dt(2016, 1, 4), 4)],
+                                                 (dt(2016, 1, 1), 3),
+                                                 (dt(2016, 1, 2), 2),
+                                                 (dt(2016, 1, 2), 4)],
                                                 names=['date', 'security']))
     assert_frame_equal(library.read('dti_test').data, df)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1310,3 +1310,25 @@ def test_pandas_dti_with_strings(library):
     library.write('dti_test', df, chunk_size='D')
     read_df = library.read('dti_test').data
     assert_frame_equal(read_df, df)
+
+
+def test_pandas_dti_with_strings_multiindex_append(library):
+    df = DataFrame(data={'data': ['A', 'BBB', 'CC']},
+                   index=MultiIndex.from_tuples([(dt(2016, 1, 1), 2),
+                                                 (dt(2016, 1, 2), 3),
+                                                 (dt(2016, 1, 3), 2)],
+                                                names=['date', 'security']))
+    library.write('dti_test', df, chunk_size='D')
+    read_df = library.read('dti_test').data
+    assert_frame_equal(read_df, df)
+    df2 = DataFrame(data={'data': ['AAAAAAA']},
+                    index=MultiIndex.from_tuples([(dt(2016, 1, 4), 4)],
+                                                 names=['date', 'security']))
+    library.append('dti_test', df2)
+    df = DataFrame(data={'data': ['A', 'BBB', 'CC', 'AAAAAAA']},
+                   index=MultiIndex.from_tuples([(dt(2016, 1, 1), 2),
+                                                 (dt(2016, 1, 2), 3),
+                                                 (dt(2016, 1, 3), 2),
+                                                 (dt(2016, 1, 4), 4)],
+                                                names=['date', 'security']))
+    assert_frame_equal(library.read('dti_test').data, df)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1289,3 +1289,24 @@ def test_pandas_dti_update_same_series(library):
     with patch.object(NdarrayStore, 'chunked_update') as p:
         library.update('dti_test', df)
     assert(not p.chunked_update.called)
+
+
+def test_pandas_dti_df_with_multiindex(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=MultiIndex.from_tuples([(dt(2016, 1, 1), 2),
+                                                 (dt(2016, 1, 2), 3),
+                                                 (dt(2016, 1, 3), 2)],
+                                                names=['date', 'security']))
+    library.write('pandas', df, chunk_size='D')
+    saved_df = library.read('pandas').data
+    assert np.all(df.values == saved_df.values)
+
+
+def test_pandas_dti_with_strings(library):
+    df = DataFrame(data={'data': ['A', 'B', 'C']},
+                   index=pd.Index(data=[dt(2016, 1, 1),
+                                        dt(2016, 1, 2),
+                                        dt(2016, 1, 3)], name='date'))
+    library.write('dti_test', df, chunk_size='D')
+    read_df = library.read('dti_test').data
+    assert_frame_equal(read_df, df)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1239,7 +1239,6 @@ def test_pandas_dti_append_and_update(library):
     library.write('dti_test', df, chunk_size='D')
     library.append('dti_test', df2)
     library.update('dti_test', df3)
-    print library.read('dti_test').data
     assert_frame_equal(library.read('dti_test').data, equals)
 
 
@@ -1248,6 +1247,43 @@ def test_pandas_dti_update_same_df(library):
                    index=pd.Index(data=[dt(2016, 1, 1),
                                         dt(2016, 1, 2),
                                         dt(2016, 1, 3)], name='date'))
+    library.write('dti_test', df, chunk_size='D')
+
+    with patch.object(NdarrayStore, 'chunked_update') as p:
+        library.update('dti_test', df)
+    assert(not p.chunked_update.called)
+
+
+def test_pandas_dti_update_series(library):
+    df = Series(data=[1, 2, 3],
+                index=pd.Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)], name='date'),
+                name='data')
+    df2 = Series(data=[20, 30, 40],
+                 index=pd.Index(data=[dt(2016, 1, 2),
+                                      dt(2016, 1, 3),
+                                      dt(2016, 1, 4)], name='date'),
+                 name='data')
+
+    equals = Series(data=[1, 20, 30, 40],
+                    index=pd.Index(data=[dt(2016, 1, 1),
+                                         dt(2016, 1, 2),
+                                         dt(2016, 1, 3),
+                                         dt(2016, 1, 4)], name='date'),
+                    name='data')
+
+    library.write('dti_test', df, chunk_size='D')
+    library.update('dti_test', df2)
+    assert_series_equal(library.read('dti_test').data, equals)
+
+
+def test_pandas_dti_update_same_series(library):
+    df = Series(data=[1, 2, 3],
+                index=pd.Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)], name='date'),
+                name='data')
     library.write('dti_test', df, chunk_size='D')
 
     with patch.object(NdarrayStore, 'chunked_update') as p:

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1250,9 +1250,9 @@ def test_pandas_dti_update_same_df(library):
                                         dt(2016, 1, 3)], name='date'))
     library.write('dti_test', df, chunk_size='D')
 
-    with patch.object(NdarrayStore, 'chunked_update') as p:
+    with patch.object(NdarrayStore, '_chunked_update') as p:
         library.update('dti_test', df)
-    assert(not p.chunked_update.called)
+    assert(not p._chunked_update.called)
 
 
 def test_pandas_dti_update_series(library):
@@ -1287,9 +1287,9 @@ def test_pandas_dti_update_same_series(library):
                 name='data')
     library.write('dti_test', df, chunk_size='D')
 
-    with patch.object(NdarrayStore, 'chunked_update') as p:
+    with patch.object(NdarrayStore, '_chunked_update') as p:
         library.update('dti_test', df)
-    assert(not p.chunked_update.called)
+    assert(not p._chunked_update.called)
 
 
 def test_pandas_dti_df_with_multiindex(library):

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1156,3 +1156,32 @@ def test_pandas_dti_write_with_append_series(library):
     library.write('dti_test', df2, chunk_size='M')
     ret = library.read('dti_test', date_range=DateRange(dt(2016, 1, 1), dt(2016, 1, 3))).data
     assert_series_equal(df2, ret)
+
+
+def test_pandas_dti_empty_range(library):
+    df = DataFrame(data={'data': [1], 'values': [10]},
+                   index=Index(data=[dt(2016, 1, 1)], name='date'))
+    library.write('dti_test', df, chunk_size='D')
+    df = library.read('dti_test', date_range=DateRange(dt(2016, 1, 2))).data
+    assert(df.empty)
+
+
+def test_pandas_dti_update(library):
+    df = DataFrame(data={'data': [1, 2, 3]},
+                   index=pd.Index(data=[dt(2016, 1, 1),
+                                        dt(2016, 1, 2),
+                                        dt(2016, 1, 3)], name='date'))
+    df2 = DataFrame(data={'data': [20, 30, 40]},
+                    index=pd.Index(data=[dt(2016, 1, 2),
+                                         dt(2016, 1, 3),
+                                         dt(2016, 1, 4)], name='date'))
+
+    equals = DataFrame(data={'data': [1, 20, 30, 40]},
+                       index=pd.Index(data=[dt(2016, 1, 1),
+                                            dt(2016, 1, 2),
+                                            dt(2016, 1, 3),
+                                            dt(2016, 1, 4)], name='date'))
+
+    library.write('dti_test', df, chunk_size='D')
+    library.update('dti_test', df2)
+    assert_frame_equal(library.read('dti_test').data, equals)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -933,5 +933,99 @@ def test_pandas_dti_yearly_df(library):
                    columns=['data'])
 
     library.write('dti_test', df, chunk_size='Y')
-    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 1))).data
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 3, 3))).data
     assert_frame_equal(df, ret)
+
+
+def test_pandas_dti_yearly_series(library):
+    df = Series(data=[1, 2, 3],
+                index=Index(data=[dt(2016, 1, 1),
+                                  dt(2016, 2, 1),
+                                  dt(2016, 3, 3)],
+                            name='date'),
+                name='data')
+
+    library.write('dti_test', df, chunk_size='Y')
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 3, 3))).data
+    assert_series_equal(df, ret)
+
+
+def test_pandas_dti_append_daily(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='D')
+    df2 = DataFrame(data=[4, 5, 6],
+                    index=Index(data=[dt(2016, 1, 4),
+                                      dt(2016, 1, 5),
+                                      dt(2016, 1, 6)],
+                                name='date'),
+                    columns=['data'])
+    library.append('dti_test', df2)
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 6))).data
+    assert_frame_equal(ret, pd.concat([df, df2]))
+
+
+def test_pandas_dti_append_monthly(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 2, 1),
+                                     dt(2016, 3, 1)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='M')
+    df2 = DataFrame(data=[4, 5, 6],
+                    index=Index(data=[dt(2016, 4, 1),
+                                      dt(2016, 5, 1),
+                                      dt(2016, 6, 1)],
+                                name='date'),
+                    columns=['data'])
+    library.append('dti_test', df2)
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 12, 31))).data
+    assert_frame_equal(ret, pd.concat([df, df2]))
+
+
+def test_pandas_dti_append_yearly(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2010, 1, 1),
+                                     dt(2011, 1, 1),
+                                     dt(2012, 1, 1)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='Y')
+    df2 = DataFrame(data=[4, 5, 6],
+                    index=Index(data=[dt(2013, 1, 1),
+                                      dt(2014, 1, 1),
+                                      dt(2015, 1, 1)],
+                                name='date'),
+                    columns=['data'])
+    library.append('dti_test', df2)
+    ret = library.read('dti_test', date_range=date_range(dt(2000, 1, 1), dt(2100, 12, 31))).data
+    assert_frame_equal(ret, pd.concat([df, df2]))
+
+
+def test_pandas_dti_append_existing_chunk(library):
+    df = DataFrame(data=[1, 2, 3],
+                   index=Index(data=[dt(2016, 1, 1),
+                                     dt(2016, 1, 2),
+                                     dt(2016, 1, 3)],
+                               name='date'),
+                   columns=['data'])
+
+    library.write('dti_test', df, chunk_size='M')
+    df2 = DataFrame(data=[4, 5, 6],
+                    index=Index(data=[dt(2016, 1, 4),
+                                      dt(2016, 1, 5),
+                                      dt(2016, 1, 6)],
+                                name='date'),
+                    columns=['data'])
+    library.append('dti_test', df2)
+    ret = library.read('dti_test', date_range=date_range(dt(2016, 1, 1), dt(2016, 1, 31))).data
+    assert_frame_equal(ret, pd.concat([df, df2]))
+

--- a/tests/integration/tickstore/test_toplevel.py
+++ b/tests/integration/tickstore/test_toplevel.py
@@ -1,5 +1,4 @@
 from datetime import datetime as dt, timedelta as dtd
-from dateutil.rrule import rrule, DAILY
 import pytest
 import pandas as pd
 from pandas.util.testing import assert_frame_equal
@@ -183,3 +182,12 @@ def test_should_add_underlying_libraries_when_intialized(arctic):
     expected_results = {'FEED_2010.LEVEL1': {'start': dt(2010, 1, 1), 'end': dt(2010, 12, 31, 23, 59, 59, 999000)},
                         'FEED_2011.LEVEL1': {'start': dt(2011, 1, 1), 'end': dt(2011, 12, 31, 23, 59, 59, 999000)}}
     assert expected_results == results
+
+
+def test_read_raises(toplevel_tickstore, arctic):
+    arctic.initialize_library('FEED_2010.LEVEL1', tickstore.TICK_STORE_TYPE)
+    arctic.initialize_library('test_current.toplevel_tickstore', tickstore.TICK_STORE_TYPE)
+
+    with pytest.raises(NoDataFoundException) as e:
+        toplevel_tickstore.read('blah', DateRange(start=dt(2015, 1, 1), end=dt(2015, 1, 6)), list('ABCD'))
+    assert("No Data found for blah in range" in str(e))

--- a/tests/unit/date/test_daterange.py
+++ b/tests/unit/date/test_daterange.py
@@ -3,6 +3,7 @@ import operator
 import pytest
 import itertools
 import six
+import pickle
 
 from arctic.date import DateRange, string_to_daterange, CLOSED_CLOSED, CLOSED_OPEN, OPEN_CLOSED, OPEN_OPEN
 
@@ -51,6 +52,7 @@ test_ranges_for_parse = [
     ['2011-01-02', '2011-12-31'],
     [dt(2011, 1, 2), dt(2011, 12, 31)],
 ]
+
 
 @pytest.mark.parametrize("date_range", test_ranges_for_parse)
 def test_daterange_arg_parsing(date_range):
@@ -234,3 +236,9 @@ def test_intersection_preserves_boundaries():
     assert DateRange('20110101', '20110102', OPEN_OPEN) == DateRange('20110101', '20110102', CLOSED_OPEN).intersection(DateRange('20110101', '20110102', OPEN_OPEN))
     assert DateRange('20110101', '20110102', OPEN_OPEN) == DateRange('20110101', '20110102', OPEN_OPEN).intersection(DateRange('20110101', '20110102', OPEN_CLOSED))
 
+
+def test_daterange_pickle():
+    d = DateRange(dt(2015, 1, 1), dt(2016, 1, 1))
+    p = pickle.dumps(d)
+    d2 = pickle.loads(p)
+    assert(d == d2)

--- a/tests/unit/date/test_util.py
+++ b/tests/unit/date/test_util.py
@@ -1,11 +1,20 @@
 import pytest
-import pytz
 
 from datetime import datetime as dt
 from arctic.date import datetime_to_ms, ms_to_datetime, mktz, to_pandas_closed_closed, DateRange, OPEN_OPEN, CLOSED_CLOSED
 from arctic.date._mktz import DEFAULT_TIME_ZONE_NAME
 from arctic.date._util import to_dt
 
+
+def test_ms_to_datetime_raises():
+    with pytest.raises(TypeError) as e:
+        ms_to_datetime("test")
+    assert("expected integer" in str(e))
+
+def test_datetime_to_ms_raises():
+    with pytest.raises(TypeError) as e:
+        datetime_to_ms("test")
+    assert("expect Python datetime" in str(e))
 
 @pytest.mark.parametrize('pdt', [
                             dt(2007, 3, 25, 1, tzinfo=mktz('Europe/London')),

--- a/tests/unit/store/test_pandas_ndarray_store.py
+++ b/tests/unit/store/test_pandas_ndarray_store.py
@@ -1,11 +1,9 @@
 from mock import Mock, sentinel, patch
-from pandas.util.testing import assert_frame_equal
 from pytest import raises
 
 from arctic.store._pandas_ndarray_store import PandasStore, \
     PandasDataFrameStore, PandasPanelStore
 import numpy as np
-import pandas as pd
 from tests.util import read_str_as_pandas
 
 
@@ -104,3 +102,4 @@ def test_read_multi_index_with_no_ts_info():
     record = np.array(record.tolist(), dtype=np.dtype([('index 1', '<M8[ns]'), ('index 2', '<M8[ns]'), ('SPAM', '<f8')],
                                                       metadata={'index': ['index 1', 'index 2'], 'columns': ['SPAM']}))
     assert store._index_from_records(record).equals(df.index)
+


### PR DESCRIPTION
New store type allows user to specify the chunking method for the dataframe/series (Daily, Monthly, Yearly). Requires a datetime-indexed dataframe/series