### PR TITLE
FSF-264 Allow reading of None values from arctic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 # Coverage
 htmlcov
 .coverage
+.idea
+.cache
 coverage.xml
 junit.xml
 /tmp/

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -362,10 +362,10 @@ class VersionStore(object):
 
 
     def _do_read(self, symbol, version, from_version=None, **kwargs):
+        if version.get('deleted'):
+            raise NoDataFoundException("No data found for %s in library %s" % (symbol, self._arctic_lib.get_name()))
         handler = self._read_handler(version, symbol)
         data = handler.read(self._arctic_lib, version, symbol, from_version=from_version, **kwargs)
-        if data is None:
-            raise NoDataFoundException("No data found for %s in library %s" % (symbol, self._arctic_lib.get_name()))
         return VersionedItem(symbol=symbol, library=self._arctic_lib.get_name(), version=version['version'],
                              metadata=version.pop('metadata', None), data=data)
     _do_read_retry = mongo_retry(_do_read)

--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -427,6 +427,11 @@ def test_delete_bson_versions(library):
     assert coll.versions.count() == 0
 
 
+def test_read_none_does_not_exception(library):
+    library.write(symbol, None)
+    assert library.read(symbol).data is None
+
+
 def test_delete_item_has_symbol(library):
     library.write(symbol, ts1)
     library.write(symbol, ts2, prune_previous_version=False)


### PR DESCRIPTION
Will throw an error if the symbol exists but has been deleted (by checking the 'deleted' metadata) - tests for this behavior already exist.
Will no longer throw an exception when reading a legitimate None from version store.