### PR TITLE
MDP-934 Ensure that the time always goes forwards in a tickstore bucket

### DIFF
--- a/arctic/exceptions.py
+++ b/arctic/exceptions.py
@@ -34,7 +34,7 @@ class QuotaExceededException(ArcticException):
     pass
 
 
-class UnorderedAppendException(ArcticException):
+class UnorderedDataException(ArcticException):
     pass
 
 

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -347,22 +347,14 @@ def test_write_no_tz(tickstore_lib):
 
 
 def test_read_out_of_order(tickstore_lib):
-    DUMMY_DATA = [
-                  {'a': 1.,
-                   'b': 2.,
-                   'index': dt(2013, 6, 1, 12, 00, tzinfo=mktz('UTC'))
-                   },
-                  {'a': 3.,
-                   'b': 4.,
-                   'index': dt(2013, 6, 1, 11, 00, tzinfo=mktz('UTC'))  # Out-of-order
-                   },
-                  {'a': 3.,
-                   'b': 4.,
-                   'index': dt(2013, 6, 1, 13, 00, tzinfo=mktz('UTC'))
-                   },
-                  ]
+    data = [{'A': 120, 'D': 1}, {'A': 122, 'B': 2.0}, {'A': 3, 'B': 3.0, 'D': 1}]
+    tick_index = [dt(2013, 6, 1, 12, 00, tzinfo=mktz('UTC')),
+                  dt(2013, 6, 1, 11, 00, tzinfo=mktz('UTC')),  # Out-of-order
+                  dt(2013, 6, 1, 13, 00, tzinfo=mktz('UTC'))]
+    data = pd.DataFrame(data, index=tick_index)
+
     tickstore_lib._chunk_size = 3
-    tickstore_lib.write('SYM', DUMMY_DATA)
+    tickstore_lib.write('SYM', data)
     tickstore_lib.read('SYM', columns=None)
     assert len(tickstore_lib.read('SYM', columns=None, date_range=DateRange(dt(2013, 6, 1, tzinfo=mktz('UTC')), dt(2013, 6, 2, tzinfo=mktz('UTC'))))) == 3
     assert len(tickstore_lib.read('SYM', columns=None, date_range=DateRange(dt(2013, 6, 1, tzinfo=mktz('UTC')), dt(2013, 6, 1, 12, tzinfo=mktz('UTC'))))) == 2

--- a/tests/unit/tickstore/test_tickstore.py
+++ b/tests/unit/tickstore/test_tickstore.py
@@ -112,7 +112,7 @@ def test_tickstore_to_bucket_always_forwards_image():
     data = [{'index': dt(2014, 1, 1, 0, 1, tzinfo=mktz(tz)), 'A': 124, 'D': 0}]
     with pytest.raises(UnorderedDataException) as e:
         TickStore._to_bucket(data, symbol, initial_image)
-    print e
+
 
 def get_coldata(coldata):
     """ return values and rowmask """


### PR DESCRIPTION
We now raise an arctic.exceptions.UnorderedDataException if data goes
backwards within one chunk.