### PR TITLE
Re-cache the library quota periodically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
 
   * Bugfix: Faster TickStore querying for multiple symbols simultaneously
   * Bugfix: #147 Add get_info method to ChunkStore
+  * Bugfix: Periodically re-cache the library.quota to pick up any changes
 
 ### 1.25 (2016-05-23)
 

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -162,13 +162,14 @@ def test_get_quota():
 
 def test_check_quota_Zero():
     self = create_autospec(ArcticLibraryBinding)
-    self.quota = 0
+    self.get_library_metadata.return_value = 0
     ArcticLibraryBinding.check_quota(self)
 
 
 def test_check_quota_None():
     m = Mock(spec=ArcticLibraryBinding)
     m.quota = None
+    m.quota_countdown = 0
     m.get_library_metadata.return_value = None
     ArcticLibraryBinding.check_quota(m)
     m.get_library_metadata.assert_called_once_with('QUOTA')
@@ -178,6 +179,7 @@ def test_check_quota_None():
 def test_check_quota_Zero2():
     m = Mock(spec=ArcticLibraryBinding)
     m.quota = None
+    m.quota_countdown = 0
     m.get_library_metadata.return_value = 0
     ArcticLibraryBinding.check_quota(m)
     m.get_library_metadata.assert_called_once_with('QUOTA')
@@ -195,7 +197,7 @@ def test_check_quota_countdown():
 def test_check_quota():
     self = create_autospec(ArcticLibraryBinding)
     self.arctic = create_autospec(Arctic)
-    self.quota = 1024 * 1024 * 1024
+    self.get_library_metadata.return_value = 1024 * 1024 * 1024
     self.quota_countdown = 0
     self.arctic.__getitem__.return_value = Mock(stats=Mock(return_value={'totals':
                                                                              {'size': 900 * 1024 * 1024,
@@ -212,7 +214,7 @@ def test_check_quota():
 def test_check_quota_info():
     self = create_autospec(ArcticLibraryBinding)
     self.arctic = create_autospec(Arctic)
-    self.quota = 1024 * 1024 * 1024
+    self.get_library_metadata.return_value = 1024 * 1024 * 1024
     self.quota_countdown = 0
     self.arctic.__getitem__.return_value = Mock(stats=Mock(return_value={'totals':
                                                                              {'size': 1 * 1024 * 1024,

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -163,6 +163,7 @@ def test_get_quota():
 def test_check_quota_Zero():
     self = create_autospec(ArcticLibraryBinding)
     self.get_library_metadata.return_value = 0
+    self.quota_countdown = 0
     ArcticLibraryBinding.check_quota(self)
 
 

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -188,7 +188,7 @@ def test_check_quota_Zero2():
 
 def test_check_quota_countdown():
     self = create_autospec(ArcticLibraryBinding)
-    self.quota = 10
+    self.get_library_metadata.return_value = 10
     self.quota_countdown = 10
     ArcticLibraryBinding.check_quota(self)
     assert self.quota_countdown == 9
@@ -231,7 +231,7 @@ def test_check_quota_info():
 def test_check_quota_exceeded():
     self = create_autospec(ArcticLibraryBinding)
     self.arctic = create_autospec(Arctic)
-    self.quota = 1024 * 1024 * 1024
+    self.get_library_metadata.return_value = 1024 * 1024 * 1024
     self.quota_countdown = 0
     self.arctic.__getitem__.return_value = Mock(stats=Mock(return_value={'totals':
                                                                              {'size': 1024 * 1024 * 1024,


### PR DESCRIPTION
Previously the quota was cached indefinitely, and if the quota was increased, the new quota wasn't being picked up until the application was restarted. Re-checking the quota after every countdown (half-life) now picks up any changes made to the library whilst the application is still running.