### PR TITLE
TickStore should respect the allow_secondary flag on Arctic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.4"
-  - "3.5"
+  - "3.4.4"
+  - "3.5.1"
 install:
   - pip install --upgrade pip
   - pip install python-dateutil --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ python:
   - "3.5"
 install:
   - pip install --upgrade pip
-  - pip install python-dateutil --upgrade 
-  - pip install pytz --upgrade 
-  - pip install tzlocal --upgrade 
+  - pip install python-dateutil --upgrade
+  - pip install pytz --upgrade
+  - pip install tzlocal --upgrade
   - pip install cython --upgrade
   - pip install pymongo --upgrade
   - pip install numpy --upgrade
-  - pip install pandas --upgrade 
+  - pip install pandas --upgrade
   - pip install decorator --upgrade
   - pip install enum34 --upgrade
   - pip install lz4 --upgrade
@@ -24,4 +24,6 @@ install:
   - pip install pytest-timeout --upgrade
   - pip install pytest-xdist --upgrade
   - pip install setuptools-git --upgrade
-script: python setup.py test
+script:
+  - pip freeze
+  - python setup.py test

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 1.26
 
   * Bugfix: Faster TickStore querying for multiple symbols simultaneously
+  * Bugfix: TickStore.read now respects `allow_secondary=True`
   * Bugfix: #147 Add get_info method to ChunkStore
 
 ### 1.25 (2016-05-23)

--- a/tests/unit/tickstore/test_tickstore.py
+++ b/tests/unit/tickstore/test_tickstore.py
@@ -2,6 +2,7 @@ from datetime import datetime as dt
 from functools import partial
 from mock import create_autospec, sentinel, call
 import pytest
+from pymongo import ReadPreference
 from pymongo.collection import Collection
 import numpy as np
 import pandas as pd
@@ -164,3 +165,23 @@ def test_tickstore_pandas_to_bucket_image():
     assert bucket[SYMBOL] == symbol
     assert bucket[IMAGE_DOC] == {IMAGE: initial_image,
                                  IMAGE_TIME: initial_image['index']}
+
+
+def test__read_preference__allow_secondary_true():
+    self = create_autospec(TickStore)
+    assert TickStore._read_preference(self, True) == ReadPreference.NEAREST
+
+
+def test__read_preference__allow_secondary_false():
+    self = create_autospec(TickStore)
+    assert TickStore._read_preference(self, False) == ReadPreference.PRIMARY
+
+
+def test__read_preference__default_true():
+    self = create_autospec(TickStore, _allow_secondary=True)
+    assert TickStore._read_preference(self, None) == ReadPreference.NEAREST
+
+
+def test__read_preference__default_false():
+    self = create_autospec(TickStore, _allow_secondary=False)
+    assert TickStore._read_preference(self, None) == ReadPreference.PRIMARY


### PR DESCRIPTION
Currently this flag is used by VersionStore to allow querying replicas
for scalability.  Although Mongo supports fairly complex server
selection, in Arctic we give the user a binary choice - PRIMARY
(allow_secondary=False) or NEAREST (allow_secondary=True)