### PR TITLE
Remove timezone path dependency on *nix

### DIFF
--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -35,4 +35,11 @@ def mktz(zone=None):
     tz = dateutil.tz.gettz(zone)
     if not tz:
         raise TimezoneError('Timezone "%s" can not be read' % (zone))
+    # Stash the zone name as an attribute (as pytz does)
+    if not hasattr(tz, 'zone'):
+        tz.zone = zone
+        for p in dateutil.tz.TZPATHS:
+            if zone.startswith(p):
+                tz.zone = zone[len(p) + 1:]
+                break
     return tz

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -2,6 +2,7 @@ import bisect
 import os
 import dateutil
 import tzlocal
+import six
 
 
 class TimezoneError(Exception):
@@ -32,7 +33,7 @@ def mktz(zone=None):
     """
     if zone is None:
         zone = tzlocal.get_localzone().zone
-    zone = unicode(zone, 'ascii')
+    zone = six.u(zone, 'ascii')
     tz = dateutil.tz.gettz(zone)
     if not tz:
         raise TimezoneError('Timezone "%s" can not be read' % (zone))

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -3,47 +3,15 @@ import os
 import dateutil
 import tzlocal
 
-DEFAULT_TIME_ZONE_NAME = tzlocal.get_localzone().zone  # 'Europe/London'
-TIME_ZONE_DATA_SOURCE = u'/usr/share/zoneinfo/'
-
 
 class TimezoneError(Exception):
     pass
 
 
-class tzfile(dateutil.tz.tzfile):
-
-    def _find_ttinfo(self, dtm, laststd=0):
-        """Faster version of parent class's _find_ttinfo() as this uses bisect rather than a linear search."""
-        if dtm is None:
-            # This will happen, for example, when a datetime.time object gets utcoffset() called.
-            raise ValueError('tzinfo object can not calculate offset for date %s' % dtm)
-        ts = ((dtm.toordinal() - dateutil.tz.EPOCHORDINAL) * 86400
-                     + dtm.hour * 3600
-                     + dtm.minute * 60
-                     + dtm.second)
-        idx = bisect.bisect_right(self._trans_list, ts)
-        if len(self._trans_list) == 0 or idx == len(self._trans_list):
-            return self._ttinfo_std
-        if idx == 0:
-            return self._ttinfo_before
-        if laststd:
-            while idx > 0:
-                tti = self._trans_idx[idx - 1]
-                if not tti.isdst:
-                    return tti
-                idx -= 1
-            else:
-                return self._ttinfo_std
-        else:
-            return self._trans_idx[idx - 1]
-
-
 def mktz(zone=None):
     """
-    Return a new timezone based on the zone using the python-dateutil
-    package.  This convenience method is useful for resolving the timezone
-    names as dateutil.tz.tzfile requires the full path.
+    Return a new timezone (tzinfo object) based on the zone using the python-dateutil
+    package.
 
     The concise name 'mktz' is for convenient when using it on the
     console.
@@ -51,7 +19,8 @@ def mktz(zone=None):
     Parameters
     ----------
     zone : `String`
-           The zone for the timezone. This defaults to 'local'.
+           The zone for the timezone. This defaults to local, returning:
+           tzlocal.get_localzone()
 
     Returns
     -------
@@ -61,14 +30,9 @@ def mktz(zone=None):
     - - - - - -
     TimezoneError : Raised if a user inputs a bad timezone name.
     """
-
     if zone is None:
-        zone = DEFAULT_TIME_ZONE_NAME
-    _path = os.path.join(TIME_ZONE_DATA_SOURCE, zone)
-    try:
-        tz = tzfile(_path)
-    except (ValueError, IOError) as err:
-        raise TimezoneError('Timezone "%s" can not be read, error: "%s"' % (zone, err))
-    # Stash the zone name as an attribute (as pytz does)
-    tz.zone = zone if not zone.startswith(TIME_ZONE_DATA_SOURCE) else zone[len(TIME_ZONE_DATA_SOURCE):]
+        zone = tzlocal.get_localzone().zone
+    tz = dateutil.tz.gettz(zone)
+    if not tz:
+        raise TimezoneError('Timezone "%s" can not be read' % (zone))
     return tz

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -33,7 +33,7 @@ def mktz(zone=None):
     """
     if zone is None:
         zone = tzlocal.get_localzone().zone
-    zone = six.u(zone, 'ascii')
+    zone = six.u(zone)
     tz = dateutil.tz.gettz(zone)
     if not tz:
         raise TimezoneError('Timezone "%s" can not be read' % (zone))

--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -32,6 +32,7 @@ def mktz(zone=None):
     """
     if zone is None:
         zone = tzlocal.get_localzone().zone
+    zone = unicode(zone, 'ascii')
     tz = dateutil.tz.gettz(zone)
     if not tz:
         raise TimezoneError('Timezone "%s" can not be read' % (zone))

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -1,5 +1,5 @@
 from datetime import datetime as dt
-from mock import patch, call
+from mock import patch, call, Mock
 import numpy as np
 from numpy.testing.utils import assert_array_equal
 from pandas.util.testing import assert_frame_equal
@@ -287,7 +287,7 @@ def test_date_range_default_timezone(tickstore_lib, tz_name):
                    },
                   ]
 
-    with patch('arctic.date._mktz.DEFAULT_TIME_ZONE_NAME', tz_name):
+    with patch('tzlocal.get_localzone', return_value=Mock(zone=tz_name)):
         tickstore_lib._chunk_size = 1
         tickstore_lib.write('SYM', DUMMY_DATA)
         df = tickstore_lib.read('SYM', date_range=DateRange(20130101, 20130701), columns=None)

--- a/tests/unit/date/test_datetime_to_ms_roundtrip.py
+++ b/tests/unit/date/test_datetime_to_ms_roundtrip.py
@@ -3,7 +3,6 @@ import datetime
 from datetime import datetime as dt
 import pytz
 from arctic.date import mktz, datetime_to_ms, ms_to_datetime
-from arctic.date._mktz import DEFAULT_TIME_ZONE_NAME
 import sys
 
 
@@ -64,11 +63,11 @@ def test_datetime_roundtrip_local_no_tz():
 
 
 def test_datetime_roundtrip_local_tz():
-    pdt = datetime.datetime(2012, 6, 12, 12, 12, 12, 123000, tzinfo=mktz(DEFAULT_TIME_ZONE_NAME))
+    pdt = datetime.datetime(2012, 6, 12, 12, 12, 12, 123000, tzinfo=mktz())
     pdt2 = ms_to_datetime(datetime_to_ms(pdt))
     assert pdt2 == pdt
 
-    pdt = datetime.datetime(2012, 1, 12, 12, 12, 12, 123000, tzinfo=mktz(DEFAULT_TIME_ZONE_NAME))
+    pdt = datetime.datetime(2012, 1, 12, 12, 12, 12, 123000, tzinfo=mktz())
     pdt2 = ms_to_datetime(datetime_to_ms(pdt))
     assert pdt2 == pdt
 
@@ -76,8 +75,8 @@ def test_datetime_roundtrip_local_tz():
 def test_datetime_roundtrip_est_tz():
     pdt = datetime.datetime(2012, 6, 12, 12, 12, 12, 123000, tzinfo=mktz('EST'))
     pdt2 = ms_to_datetime(datetime_to_ms(pdt))
-    assert pdt2.replace(tzinfo=mktz(DEFAULT_TIME_ZONE_NAME)) == pdt
+    assert pdt2.replace(tzinfo=mktz()) == pdt
 
     pdt = datetime.datetime(2012, 1, 12, 12, 12, 12, 123000, tzinfo=mktz('EST'))
     pdt2 = ms_to_datetime(datetime_to_ms(pdt))
-    assert pdt2.replace(tzinfo=mktz(DEFAULT_TIME_ZONE_NAME)) == pdt
+    assert pdt2.replace(tzinfo=mktz()) == pdt

--- a/tests/unit/date/test_mktz.py
+++ b/tests/unit/date/test_mktz.py
@@ -29,9 +29,9 @@ def test_mktz_noarg():
 
 def test_mktz_zone():
     tz = mktz('UTC')
-    assert 'UTC' in repr(tz)
+    assert tz.zone == "UTC"
     tz = mktz('/usr/share/zoneinfo/UTC')
-    assert 'UTC' in repr(tz)
+    assert tz.zone == "UTC"
 
 
 def test_mktz_fails_if_invalid_timezone():

--- a/tests/unit/date/test_mktz.py
+++ b/tests/unit/date/test_mktz.py
@@ -1,9 +1,11 @@
 from datetime import datetime as dt
 from mock import patch
 from pytest import raises
+import tzlocal
 
 from arctic.date import mktz, TimezoneError
-from arctic.date._mktz import DEFAULT_TIME_ZONE_NAME, tzfile, TIME_ZONE_DATA_SOURCE
+
+DEFAULT_TIME_ZONE_NAME = tzlocal.get_localzone().zone  # 'Europe/London'
 
 
 def test_mktz():
@@ -27,9 +29,9 @@ def test_mktz_noarg():
 
 def test_mktz_zone():
     tz = mktz('UTC')
-    assert tz.zone == "UTC"
+    assert 'UTC' in repr(tz)
     tz = mktz('/usr/share/zoneinfo/UTC')
-    assert tz.zone == "UTC"
+    assert 'UTC' in repr(tz)
 
 
 def test_mktz_fails_if_invalid_timezone():
@@ -37,9 +39,3 @@ def test_mktz_fails_if_invalid_timezone():
         file_exists.return_value = False
         with raises(TimezoneError):
             mktz('junk')
-
-
-def test_tzfile_raises():
-    t = tzfile(TIME_ZONE_DATA_SOURCE + DEFAULT_TIME_ZONE_NAME)
-    with raises(ValueError):
-        t._find_ttinfo(None) 

--- a/tests/unit/date/test_util.py
+++ b/tests/unit/date/test_util.py
@@ -3,7 +3,6 @@ import pytz
 
 from datetime import datetime as dt
 from arctic.date import datetime_to_ms, ms_to_datetime, mktz, to_pandas_closed_closed, DateRange, OPEN_OPEN, CLOSED_CLOSED
-from arctic.date._mktz import DEFAULT_TIME_ZONE_NAME
 from arctic.date._util import to_dt
 
 
@@ -24,7 +23,7 @@ def test_datetime_to_ms_and_back(pdt):
 
 
 def test_datetime_to_ms_and_back_microseconds():
-    pdt = dt(2012, 8, 1, 12, 34, 56, 999999, tzinfo=mktz(DEFAULT_TIME_ZONE_NAME))
+    pdt = dt(2012, 8, 1, 12, 34, 56, 999999, tzinfo=mktz())
     i = datetime_to_ms(pdt)
     pdt2 = ms_to_datetime(i)
 


### PR DESCRIPTION
- Use dateutil.tz.gettz rather than loading tzfiles directly - this
should support Windows:
  https://labix.org/python-dateutil#head-b79630fbbda87af6d6d121737510fd7ea5aeea97
- Don't load the default timezone on module import (we shouldn't do
additional I/O here)
- Remove custom tzfile binary-search implementation, this was fixed
upstream in dateutil: 
  https://github.com/dateutil/dateutil/commit/1205f3cea1452f54eee9792034e433afc0ecffc5 

Fixes #43