### PR TITLE
Fix issue #178

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@
   * Feature: #171 allow deleting of values within a date range in ChunkStore
   * Bugfix: #172 Fix date range bug when querying dates in the middle of chunks
   * Bugfix: #176 Fix overwrite failures in Chunkstore
+  * Bugfix: #178 - Change how start/end dates are populated in the DB, also fix append so it works as expected. 
 
 ### 1.25 (2016-05-23)
 

--- a/arctic/chunkstore/_chunker.py
+++ b/arctic/chunkstore/_chunker.py
@@ -24,17 +24,6 @@ class Chunker(object):
         """
         raise NotImplementedError
 
-    def to_start_end(self, item):
-        """
-        turns the data in item to  a start/end pair (same as is returned by
-        to_chunks()
-
-        returns
-        -------
-        tuple - (start, end)
-        """
-        raise NotImplementedError
-
     def to_mongo(self, range_obj):
         """
         takes the range object used for this chunker type
@@ -62,7 +51,7 @@ class Chunker(object):
         """
         raise NotImplementedError
 
-def exclude(self, data, range_obj):
+    def exclude(self, data, range_obj):
         """
         Removes data within the bounds of the range object (inclusive)
 


### PR DESCRIPTION
- Fix append
- Rework Append and Update to share code (since 99% of their code is identical)
- Change how start/end are stored in Mongo. Previously was the actual start/end of the data, now is start/end of the chunk size. This makes the code less complex. 