### PR TITLE
packaging: Exclude benchmarks and tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ setup(
     license="GPL",
     keywords=["ahl", "keyvalue", "tickstore", "mongo", "timeseries", ],
     url="https://github.com/manahl/arctic",
-    packages=find_packages(),
+    packages=find_packages(include=("arctic*", )),
     long_description='\n'.join((long_description, changelog)),
     cmdclass={'test': PyTest},
     ext_modules=cythonize(compress),


### PR DESCRIPTION
There're somehow two `__init__.py` files inside `tests/` and `benchmarks/`, which will be included in the arctic dist package:

```
In [3]: find_packages()
Out[3]:
['arctic',
 'benchmarks',
 'tests',
 'arctic.chunkstore',
 'arctic.date',
 'arctic.fixtures',
 'arctic.scripts',
 'arctic.serialization',
 'arctic.store',
 'arctic.tickstore',
 'tests.integration',
 'tests.unit',
 'tests.integration.chunkstore',
 'tests.integration.fixtures',
 'tests.integration.scripts',
 'tests.integration.store',
 'tests.integration.tickstore',
 'tests.unit.date',
 'tests.unit.scripts',
 'tests.unit.serialization',
 'tests.unit.store',
 'tests.unit.tickstore']
In [4]: find_packages(include=("arctic*", ))
Out[4]:
['arctic',
 'arctic.chunkstore',
 'arctic.date',
 'arctic.fixtures',
 'arctic.scripts',
 'arctic.serialization',
 'arctic.store',
 'arctic.tickstore']
```

When arctic is installed from source or PyPI. `tests` and `benchmarks` will also be installed. Which is smelly. 

```
In [6]: import arctic

In [7]: import tests

In [8]: import benchmarks

In [9]: benchmarks.__file__
Out[9]: '/vagrant/projects/xxx/venv/lib/python2.7/site-packages/benchmarks/__init__.pyc'
```