### PR TITLE
TickStore: Fix ZeroDivisionError

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -335,7 +335,8 @@ class TickStore(object):
 
         t = (dt.now() - perf_start).total_seconds()
         ticks = len(rtn)
-        logger.info("%d rows in %s secs: %s ticks/sec" % (ticks, t, int(ticks / t)))
+        rate = int(ticks / t) if t != 0 else float("nan")
+        logger.info("%d rows in %s secs: %s ticks/sec" % (ticks, t, rate))
         if not rtn.index.is_monotonic:
             logger.error("TimeSeries data is out of order, sorting!")
             rtn = rtn.sort_index(kind='mergesort')
@@ -537,7 +538,8 @@ class TickStore(object):
         mongo_retry(self._collection.insert_many)(buckets)
         t = (dt.now() - start).total_seconds()
         ticks = len(buckets) * self._chunk_size
-        logger.debug("%d buckets in %s: approx %s ticks/sec" % (len(buckets), t, int(ticks / t)))
+        rate = int(ticks / t) if t != 0 else float("nan")
+        logger.debug("%d buckets in %s: approx %s ticks/sec" % (len(buckets), t, rate))
 
     def _pandas_to_buckets(self, x, symbol, initial_image):
         rtn = []


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/vagrant/projects/x/x/scripts/x_import_market_data.py", line 143, in run
    self.tick_library.write(instrument_id, [tick_dict])
  File "/vagrant/projects/x/venv/local/lib/python2.7/site-packages/arctic-1.26.0-py2.7-linux-x86_64.egg/arctic/tickstore/tickstore.py", line 533, in write
    self._write(buckets)
  File "/vagrant/projects/x/venv/local/lib/python2.7/site-packages/arctic-1.26.0-py2.7-linux-x86_64.egg/arctic/tickstore/tickstore.py", line 540, in _write
    logger.debug("%d buckets in %s: approx %s ticks/sec" % (len(buckets), t, int(ticks / t)))
ZeroDivisionError: float division by zero
```

This traceback looks strange but any it happened (just once in my setup). It looks like we can't expect `delta != 0` where

```python
t1 = datetime.now()
# do something
t2 = datetime.now()
delta = (t2 - t1).total_seconds()
```

```bash
$ ag "/sec"
tickstore/tickstore.py
339:        logger.info("%d rows in %s secs: %s ticks/sec" % (ticks, t, rate))
542:        logger.debug("%d buckets in %s: approx %s ticks/sec" % (len(buckets), t, rate))
```


