### PR TITLE
Pytest fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ install:
   - pip install mockextras
   - pip install pytest==2.9.2
   - pip install pytest-cov==2.3.0
-  - pip install pytest-dbfixtures --upgrade
-  - pip install pytest-timeout --upgrade
-  - pip install pytest-xdist --upgrade
+  - pip install pytest-dbfixtures==0.15.0
+  - pip install pytest-timeout
+  - pip install pytest-xdist
   - pip install setuptools-git --upgrade
 script:
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,8 @@ install:
   - pip install pytest==2.9.2
   - pip install pytest-cov==2.3.0
   - pip install pytest-dbfixtures==0.15.0
-  - pip install pytest-timeout
-  - pip install pytest-xdist
+  - pip install pytest-timeout==1.0.0
+  - pip install pytest-xdist==1.15.0
   - pip install setuptools-git --upgrade
 script:
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   - pip install lz4 --upgrade
   - pip install mock --upgrade
   - pip install mockextras
+  - pip install pytest==2.9.2
   - pip install pytest-cov --upgrade
   - pip install pytest-dbfixtures --upgrade
   - pip install pytest-timeout --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   - pip install mock --upgrade
   - pip install mockextras
   - pip install pytest==2.9.2
-  - pip install pytest-cov --upgrade
+  - pip install pytest-cov==2.3.0
   - pip install pytest-dbfixtures --upgrade
   - pip install pytest-timeout --upgrade
   - pip install pytest-xdist --upgrade

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
   - pip install lz4 --upgrade
   - pip install mock --upgrade
   - pip install mockextras
-  - pip install pytest --upgrade
   - pip install pytest-cov --upgrade
   - pip install pytest-dbfixtures --upgrade
   - pip install pytest-timeout --upgrade

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     tests_require=["mock",
                    "mockextras",
                    "pytest<=2.9.2",
-                   "pytest-cov<=2.3.0",
+                   "pytest-cov",
                    "pytest-dbfixtures",
                    "pytest-timeout",
                    "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
     tests_require=["mock",
                    "mockextras",
                    "pytest<=2.9.2",
-                   "pytest-cov",
+                   "pytest-cov<=2.3.0",
                    "pytest-dbfixtures>=0.15.0",
                    "pytest-timeout",
                    "pytest-xdist",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
                    "mockextras",
                    "pytest<=2.9.2",
                    "pytest-cov<=2.3.0",
-                   "pytest-dbfixtures>=0.15.0",
+                   "pytest-dbfixtures",
                    "pytest-timeout",
                    "pytest-xdist",
                    ],

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,7 @@ setup(
                       ],
     tests_require=["mock",
                    "mockextras",
-                   "pytest",
+                   "pytest<=2.9.2",
                    "pytest-cov",
                    "pytest-dbfixtures>=0.15.0",
                    "pytest-timeout",

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
                    "mockextras",
                    "pytest<=2.9.2",
                    "pytest-cov",
-                   "pytest-dbfixtures",
+                   "pytest-dbfixtures>=0.15.0",
                    "pytest-timeout",
                    "pytest-xdist",
                    ],


### PR DESCRIPTION
Latest version of PyTest deprecates a call that pytest-dbfixtures makes, resulting in an error when running pytest. This forces setup.py and Travis to use the previous version of pytest