### PR TITLE
Fixes issue 214 - Tickstore not supporting data frames with string cols

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -587,7 +587,7 @@ class TickStore(object):
             array = array.astype('<i8')
         elif (array.dtype.kind) == 'f':
             array = array.astype('<f8')
-        elif (array.dtype.kind) in ('U', 'S'):
+        elif (array.dtype.kind) in ('U', 'S', 'O'):
             array = array.astype(np.unicode_)
         else:
             raise UnhandledDtypeException("Unsupported dtype '%s' - only int64, float64 and U are supported" % array.dtype)


### PR DESCRIPTION
This pull request fixes issue 214, at least for the specific needs I have.

The fix simply allows for dtype.kind = 'O' to be casted to unicode to support strings.