### PR TITLE
Don't raise during append(...) if the previous append didn't succeed.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   * Feature: #204 Add support for library renaming
   * Feature: #209 Upsert capability in ChunkStore's update method
   * Feature: #207 Support DatetimeIndexes in DateRange chunker
+  * Bugfix:  #232 Don't raise during VersionStore #append(...) if the previous append failed
 
 ### 1.28 (2016-08-16)
 

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -483,8 +483,8 @@ class VersionStore(object):
         assert previous_version is not None
 
         # If the version numbers aren't in line, then we've lost some data.
-        next_ver = self._version_nums.find_one({'symbol': symbol, 'version': previous_version['version']})
-        if next_ver is None:
+        next_ver = self._version_nums.find_one({'symbol': symbol})['version']
+        if next_ver != previous_version['version']:
             logger.error('''version_nums is out of sync with previous version document. 
             This probably means that either a version document write has previously failed, or the previous version has been deleted.
             There will be a gap in the data.''')
@@ -508,7 +508,7 @@ class VersionStore(object):
             raise Exception("Append not implemented for handler %s" % handler)
 
         # Get the next version number  - check there hasn't been a concurrent write
-        next_ver = self._version_nums.find_one_and_update({'symbol': symbol, 'version': previous_version['version']},
+        next_ver = self._version_nums.find_one_and_update({'symbol': symbol, 'version': next_ver},
                                                       {'$inc': {'version': 1}},
                                                       upsert=False, new=True)
         if next_ver is None:

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -482,12 +482,12 @@ class VersionStore(object):
 
         assert previous_version is not None
 
+        # If the version numbers aren't in line, then we've lost some data.
         next_ver = self._version_nums.find_one({'symbol': symbol, 'version': previous_version['version']})
-
         if next_ver is None:
-            raise ArcticException('''version_nums is out of sync with previous version document. 
+            logger.error('''version_nums is out of sync with previous version document. 
             This probably means that either a version document write has previously failed, or the previous version has been deleted.
-            Append not possible - please call write() to get versions back in sync''')
+            There will be a gap in the data.''')
 
         # if the symbol has previously been deleted then overwrite
         previous_metadata = previous_version.get('metadata', None)
@@ -507,12 +507,11 @@ class VersionStore(object):
         else:
             raise Exception("Append not implemented for handler %s" % handler)
 
+        # Get the next version number  - check there hasn't been a concurrent write
         next_ver = self._version_nums.find_one_and_update({'symbol': symbol, 'version': previous_version['version']},
                                                       {'$inc': {'version': 1}},
                                                       upsert=False, new=True)
-
         if next_ver is None:
-            #Latest version has changed during this operation
             raise OptimisticLockException()
 
         version['version'] = next_ver['version']


### PR DESCRIPTION
It can be the case that the previous append fails (which is reported
back to the caller), and subsequent appends won't be allowed until a
read()+write() are called.  Log an error, but allow the new append to
proceed.

Fixes MDP-1054 / Issue #228