### PR TITLE
MDP-1292 Don't ensure_index on every VersionStore.append() / write()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
   * Bugfix: #249 open ended range reads on data without index fail
   * Bugfix: #262 VersionStore.append must check data is written correctly during repack
   * Bugfix: #263 Quota: Improve the error message when near soft-quota limit
+  * Perf:   #265 VersionStore.write / append don't aggressively add indexes on each write
   
 ### 1.31 (2016-09-29)
   

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -465,7 +465,6 @@ class VersionStore(object):
         upsert : `bool`
             Write 'data' if no previous version exists.
         """
-        self._ensure_index()
         self._arctic_lib.check_quota()
         version = {'_id': bson.ObjectId()}
         version['symbol'] = symbol
@@ -556,7 +555,6 @@ class VersionStore(object):
         VersionedItem named tuple containing the metadata and verison number
         of the written symbol in the store.
         """
-        self._ensure_index()
         self._arctic_lib.check_quota()
         version = {'_id': bson.ObjectId()}
         version['symbol'] = symbol

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -129,20 +129,6 @@ def test_read_metadata_no_asof():
                                                          sort=[('version', pymongo.DESCENDING)])]
 
 
-def test_write_ensure_index():
-    write_handler = Mock(write=Mock(__name__=""))
-    vs = create_autospec(VersionStore, instance=True,
-                     _collection=Mock(),
-                     _version_nums=Mock(find_one_and_update=Mock(return_value={'version':1})),
-                     _versions=Mock(insert_one=lambda x:None),
-                     _arctic_lib=Mock(),
-                     _publish_changes=False)
-    vs._collection.database.connection.nodes = []
-    vs._write_handler.return_value = write_handler
-    VersionStore.write(vs, 'sym', sentinel.data, prune_previous_version=False)
-    vs._ensure_index.assert_called_once_with()
-
-
 def test_write_check_quota():
     write_handler = Mock(write=Mock(__name__=""))
     vs = create_autospec(VersionStore, instance=True,


### PR DESCRIPTION
ensure_index takes a database write lock, which may be very slow.  We
already create the indexes on library initialisation.

For example:

```
2016-10-18T09:57:15.891+0100 I COMMAND [conn2904064] command
mongoose_oneminute.$cmd command: createIndexes { createIndexes: "LIVE",
indexes: [ { unique: true, background: true, name: "symbol_1_sha_1",
key: { symbol: 1, sha: 1 } } ] } keyUpdates:0 writeConflicts:0
numYields:0 reslen:149 locks:{ Global: {
 acquireCount: { r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2
}, acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 235168 } },
Database: { acquireCount: { W: 1 }, acquireWaitCount: { W: 1 },
timeAcquiringMicros: { W: 836 } } } 236ms
2016-10-18T09:57:15.891+0100 I COMMAND [conn2904078] command
mongoose_oneminute.$cmd command: createIndexes { createIndexes: "LIVE",
indexes: [ { background: true, name: "symbol_hashed", key: { symbol:
"hashed" } } ] } keyUpdates:0 writeConflicts:0 numYields:0 reslen:149
locks:{ Global: { acquireCount: {
 r: 1, w: 1 } }, MMAPV1Journal: { acquireCount: { w: 2 },
acquireWaitCount: { w: 1 }, timeAcquiringMicros: { w: 228768 } },
Database: { acquireCount: { W: 1 }, acquireWaitCount: { W: 1 },
timeAcquiringMicros: { W: 879 } } } 229ms
```