### PR TITLE
Move chunkstores per-chunk metadata to its own collection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 1.34
 
+  * Feature: #294 Move per-chunk metadata for chunkstore to a separate collection
   * Bugfix:  #292 Account for metadata size during size chunking in ChunkStore
   * Feature: #283 Support for all pandas frequency strings in ChunkStore DateChunker
   * Feature: #286 Add has_symbol to ChunkStore and support for partial symbol matching in list_symbols

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -1205,3 +1205,20 @@ def test_list_symbols(chunkstore_lib):
 
     assert(chunkstore_lib.has_symbol('dragon'))
     assert(chunkstore_lib.has_symbol('marmot') is False)
+
+
+def test_stats(chunkstore_lib):
+    df = DataFrame(data={'data': np.random.randint(0, 100, size=366)},
+                   index=pd.date_range('2016-01-01', '2016-12-31'))
+    df.index.name = 'date'
+
+    chunkstore_lib.write('rabbit', df)
+    chunkstore_lib.write('dragon', df)
+    chunkstore_lib.write('snake', df)
+    chunkstore_lib.write('wolf', df)
+    chunkstore_lib.write('bear', df)
+
+    s = chunkstore_lib.stats()
+    assert(s['symbols']['count'] == 5)
+    assert(s['chunks']['count'] == 366 * 5)
+    assert(s['chunks']['count'] == s['metadata']['count'])


### PR DESCRIPTION
This change will help future proof the storage of metadata, and allow us to store per symbol user defined metadata (not implemented yet). Also prevents a vert large sized metadata from drastically reducing the chunking size of every part of a chunk for chunks over 16MB.