### PR TITLE
Decompression fails with empty string

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 1.35
+
+  * Bugfix:  #296 Cannot compress/decompress empty string
+
 ### 1.34 (2016-11-29)
 
   * Feature: #294 Move per-chunk metadata for chunkstore to a separate collection

--- a/src/_compress.pyx
+++ b/src/_compress.pyx
@@ -116,7 +116,7 @@ def decompress(pString):
     result = <char*>malloc(original_size)
     # decompress
     ret = LZ4_decompress_safe(cString + hdr_size, result, compressed_size - hdr_size, original_size)
-    if ret <= 0 or ret != original_size:
+    if ret != original_size:
         free(result)
         raise Exception("Error decompressing")
     # cast back into python string

--- a/tests/unit/test_compression.py
+++ b/tests/unit/test_compression.py
@@ -7,7 +7,6 @@ def test_compress():
     assert len(compress(b'foobar')) > 0
 
 
-
 def test_compress_LZ4():
     cfn = Mock()
     with patch('arctic._compression.clz4.compress', cfn):
@@ -26,6 +25,7 @@ def test_compress_array_usesLZ4():
         compress_array([b"foo"] * 100)
         assert cfn.call_count == 1
 
+
 def test_compress_array_LZ4_sequential():
     cfn = Mock()
     with patch('arctic._compression.clz4.compress', cfn):
@@ -41,6 +41,7 @@ def test_decompress_array():
     ll = [('foo%s' % i).encode('ascii') for i in range(100)]
     assert decompress_array(compress_array(ll)) == ll
 
+
 def test_compression_equal_regardless_parallel_mode():
     a = [b'spam '] * 666
     with patch('arctic._compression.ENABLE_PARALLEL', True):
@@ -52,8 +53,8 @@ def test_compression_equal_regardless_parallel_mode():
 
 def test_compress_decompress_no_parallel():
     with patch('arctic._compression.clz4', sentinel.clz4), \
-         patch('arctic._compression.ENABLE_PARALLEL', False), \
-         patch('arctic._compression.lz4', wraps=lz4) as patch_lz4:
+        patch('arctic._compression.ENABLE_PARALLEL', False), \
+        patch('arctic._compression.lz4', wraps=lz4) as patch_lz4:
         # patching clz4 with sentinel will make accessing any clz4 function explode
         assert decompress(compress(b'Foo')) == b'Foo'
         assert patch_lz4.compress.call_args_list == [call(b'Foo')]
@@ -63,8 +64,8 @@ def test_compress_decompress_no_parallel():
 def test_compress_array_no_parallel():
     a = [b'spam', b'egg', b'spamm', b'spammm']
     with patch('arctic._compression.clz4', sentinel.clz4), \
-         patch('arctic._compression.ENABLE_PARALLEL', False), \
-         patch('arctic._compression.lz4', wraps=lz4) as patch_lz4:
+        patch('arctic._compression.ENABLE_PARALLEL', False), \
+        patch('arctic._compression.lz4', wraps=lz4) as patch_lz4:
         assert decompress_array(compress_array(a)) == a
         assert patch_lz4.compress.call_args_list == [call(x) for x in a]
         assert patch_lz4.decompress.call_args_list == [call(compress(x)) for x in a]
@@ -73,8 +74,11 @@ def test_compress_array_no_parallel():
 def test_enable_parallel_lz4():
     enable_parallel_lz4(True)
     from arctic._compression import ENABLE_PARALLEL
-    assert(ENABLE_PARALLEL == True)
+    assert(ENABLE_PARALLEL is True)
     enable_parallel_lz4(False)
     from arctic._compression import ENABLE_PARALLEL
-    assert(ENABLE_PARALLEL == False)
+    assert(ENABLE_PARALLEL is False)
 
+
+def test_compress_empty_string():
+    assert(decompress(compress('')) == '')


### PR DESCRIPTION
Bug in the Cython code considered a return code of 0 to mean the decompression failed. 0 is a valid code when the size of the data is zero (i.e. emptry string).