### PR TITLE
Cache for mktz

### DIFF
--- a/arctic/date/_mktz.py
+++ b/arctic/date/_mktz.py
@@ -3,6 +3,10 @@ import os
 import dateutil
 import tzlocal
 import six
+import weakref
+
+
+_TZ_CACHE = weakref.WeakValueDictionary()
 
 
 class TimezoneError(Exception):
@@ -34,6 +38,11 @@ def mktz(zone=None):
     if zone is None:
         zone = tzlocal.get_localzone().zone
     zone = six.u(zone)
+
+    cached = _TZ_CACHE.get(zone)
+    if cached is not None:
+        return cached
+
     tz = dateutil.tz.gettz(zone)
     if not tz:
         raise TimezoneError('Timezone "%s" can not be read' % (zone))
@@ -44,4 +53,5 @@ def mktz(zone=None):
             if zone.startswith(p):
                 tz.zone = zone[len(p) + 1:]
                 break
+    _TZ_CACHE[zone] = tz
     return tz


### PR DESCRIPTION
My app use `ms_to_datetime` frequently, after profiling using [pyflame](https://github.com/uber/pyflame), I found the function takes `35.62%` of the total CPU time, and the bottleneck is in `mktz`(`31.87%`). I think it's better to cache results for the `mktz` function.