### PR TITLE
Update travis.yml to use container build infrastructure again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,11 @@
-sudo: required
 dist: trusty
+sudo: false
 language: python
 python:
   - "2.7"
   - "3.4.5"
   - "3.5.2"
 before_install:
-  - sudo apt-key adv --keyserver keys.gnupg.net --recv 6DA70622
-  - sudo echo "deb http://downloads.ortussolutions.com/debs/noarch /" | sudo tee -a /etc/apt/sources.list.d/commandbox.list
   - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
   - sudo echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee -a /etc/apt/sources.list.d/mongodb-org-3.2.list
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ addons:
       - mongodb-3.2-precise
     packages:
       - mongodb-org-server
+      - mongodb-org-shell
 services:
    - mongodb
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ python:
   - "2.7"
   - "3.4.5"
   - "3.5.2"
-before_install:
-  - sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv EA312927
-  - sudo echo "deb http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.2 multiverse" | sudo tee -a /etc/apt/sources.list.d/mongodb-org-3.2.list
 install:
   - sudo apt-get update && sudo apt-get --assume-yes install mongodb-org
   - mongo --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,21 @@
-dist: trusty
+dist: precise
 sudo: false
 language: python
 python:
   - "2.7"
   - "3.4.5"
   - "3.5.2"
+
+addons:
+  apt:
+    sources:
+      - mongodb-3.2-precise
+    packages:
+      - mongodb-org-server
+services:
+   - mongodb
+
 install:
-  - sudo apt-get update && sudo apt-get --assume-yes install mongodb-org
   - mongo --version
   - pip install --upgrade pip
   - pip install python-dateutil --upgrade


### PR DESCRIPTION
With most recent updates to the server test fixtures (pytest-server-fixtures) we
should be able to run with sudo: false again, thus enabling containers again. This
will result in a small but noticeable speedup in build times