### PR TITLE
Better format for DateRange.__str__

### DIFF
--- a/arctic/date/_daterange.py
+++ b/arctic/date/_daterange.py
@@ -191,7 +191,13 @@ class DateRange(GeneralSlice):
         else:
             raise IndexError('Index %s not in range (0:1)' % key)
 
-    __str__ = __repr__
+    def __str__(self):
+        return "%s%s, %s%s" % (
+            "(" if self.startopen else "[",
+            self.start,
+            self.end,
+            ")" if self.endopen else "]",
+        )
 
     def __setstate__(self, state):
         """Called by pickle, PyYAML etc to set state."""


### PR DESCRIPTION
```python
DateRange(start=datetime.datetime(2016, 12, 25, 18, 23, 34, 15000, tzinfo=tzfile(u'/usr/share/zoneinfo/Asia/Shanghai')), end=datetime.datetime(2016, 12, 25, 20, 23, 34, 15000, tzinfo=tzfile(u'/usr/share/zoneinfo/Asia/Shanghai')))
```

looks good for `__repr__` but too ugly for `__str__`, especially in logs.

I think

```python
[2016-12-25 18:23:34.015000+08:00, 2016-12-25 20:23:34.015000+08:00)
```

should be much better.