### PR TITLE
Support for audit logs in ChunkStore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   * Bugfix:  #300 to_datetime deprecated in pandas, use to_pydatetime instead
   * Bugfix:  #309 formatting change for DateRange ```__str__```
   * Feature: #313 set and read user specified metadata in chunkstore
+  * Feature: #319 Audit log support in ChunkStore
 
 ### 1.36 (2016-12-13)
   

--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -118,8 +118,8 @@ class ChunkStore(object):
             symbol name for the item
         chunk_range: range object
             a date range to delete
-        audit: json
-            json to store in the audit log
+        audit: dict
+            dict to store in the audit log
         """
         if chunk_range is not None:
             sym = self._get_symbol_info(symbol)
@@ -178,9 +178,6 @@ class ChunkStore(object):
 
     def _get_symbol_info(self, symbol):
         return self._symbols.find_one({SYMBOL: symbol})
-    
-    def _get_audit_info(self, symbol):
-        return self._audit.find_one({SYMBOL: symbol})
 
     def rename(self, from_symbol, to_symbol, audit=None):
         """


### PR DESCRIPTION
Enable audit logs on operations with the audit keyword arg. Writes supplied dict along with additional information into the audit collection