### PR TITLE
Fix issue #324

### DIFF
--- a/arctic/chunkstore/date_chunker.py
+++ b/arctic/chunkstore/date_chunker.py
@@ -29,7 +29,7 @@ class DateChunker(Chunker):
         elif 'date' in df.columns:
             dates = pd.DatetimeIndex(df.date)
             if not dates.is_monotonic_increasing:
-                df = df.sort_values(by='date')
+                df = df.sort(columns='date')
                 dates = pd.DatetimeIndex(df.date)
         else:
             raise Exception("Data must be datetime indexed or have a column named 'date'")

--- a/arctic/chunkstore/date_chunker.py
+++ b/arctic/chunkstore/date_chunker.py
@@ -24,8 +24,13 @@ class DateChunker(Chunker):
         """
         if 'date' in df.index.names:
             dates = df.index.get_level_values('date')
+            if not df.index.is_monotonic_increasing:
+                df = df.sort_index()
         elif 'date' in df.columns:
             dates = pd.DatetimeIndex(df.date)
+            if not dates.is_monotonic_increasing:
+                df = df.sort_values(by='date')
+                dates = pd.DatetimeIndex(df.date)
         else:
             raise Exception("Data must be datetime indexed or have a column named 'date'")
 

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -1354,7 +1354,7 @@ def test_unsorted_date_col(chunkstore_lib):
                         'vals': range(2)})
 
     chunkstore_lib.write('test_symbol', df)
-    assert_frame_equal(df.sort_values(by='date').reset_index(drop=True), chunkstore_lib.read('test_symbol'))
+    assert_frame_equal(df.sort(columns='date').reset_index(drop=True), chunkstore_lib.read('test_symbol'))
     chunkstore_lib.update('test_symbol', df2)
     assert_frame_equal(chunkstore_lib.read('test_symbol'), 
                        pd.DataFrame({'date': pd.date_range('2016-8-31',

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -1331,5 +1331,33 @@ def test_chunkstore_misc(chunkstore_lib):
     
     assert("arctic_test.TEST" in str(chunkstore_lib))
     assert(str(chunkstore_lib) == repr(chunkstore_lib))
+
+
+def test_unsorted_index(chunkstore_lib):
+    df = pd.DataFrame({'date': [dt(2016,9,1), dt(2016,8,31)],
+                       'vals': range(2)}).set_index('date')
+    df2 = pd.DataFrame({'date': [dt(2016,9,2), dt(2016,9,1)],
+                        'vals': range(2)}).set_index('date')
     
+    chunkstore_lib.write('test_symbol', df)
+    assert_frame_equal(df.sort_index(), chunkstore_lib.read('test_symbol'))
+    chunkstore_lib.update('test_symbol', df2)
+    assert_frame_equal(chunkstore_lib.read('test_symbol'), 
+                       pd.DataFrame({'date': pd.date_range('2016-8-31',
+                                                           '2016-9-2'),
+                                     'vals': [1,1,0]}).set_index('date'))
     
+def test_unsorted_date_col(chunkstore_lib):
+    df = pd.DataFrame({'date': [dt(2016,9,1), dt(2016,8,31)],
+                       'vals': range(2)})
+    df2 = pd.DataFrame({'date': [dt(2016,9,2), dt(2016,9,1)],
+                        'vals': range(2)})
+
+    chunkstore_lib.write('test_symbol', df)
+    assert_frame_equal(df.sort_values(by='date').reset_index(drop=True), chunkstore_lib.read('test_symbol'))
+    chunkstore_lib.update('test_symbol', df2)
+    assert_frame_equal(chunkstore_lib.read('test_symbol'), 
+                       pd.DataFrame({'date': pd.date_range('2016-8-31',
+                                                           '2016-9-2'),
+                                     'vals': [1,1,0]}))
+


### PR DESCRIPTION
fixes issue #324. Pandas doesnt do well with unsorted datetime indexes, so this ensures that they are sorted