### PR TITLE
MDP-1754 Improve the memory and cpu performance of reading a subset of columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 ### 1.38
 
+  * Feature: #290 improve performance of tickstore column reads
+
 ### 1.37 (2017-1-31)
   * Bugfix:  #300 to_datetime deprecated in pandas, use to_pydatetime instead
   * Bugfix:  #309 formatting change for DateRange ```__str__```

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -85,12 +85,12 @@ def test_read_allow_secondary(tickstore_lib):
 
 def test_read_symbol_as_column(tickstore_lib):
     data = [{'ASK': 1545.25,
-                  'index': 1185076787070},
-                 {'CUMVOL': 354.0,
-                  'index': 1185141600600}]
+             'index': 1185076787070},
+            {'CUMVOL': 354.0,
+             'index': 1185141600600}]
     tickstore_lib.write('FEED::SYMBOL', data)
 
-    df = tickstore_lib.read('FEED::SYMBOL', columns=['SYMBOL'])
+    df = tickstore_lib.read('FEED::SYMBOL', columns=['SYMBOL', 'CUMVOL'])
     assert all(df['SYMBOL'].values == ['FEED::SYMBOL'])
 
 
@@ -596,15 +596,12 @@ def test_read_with_image(tickstore_lib):
     # Read one column from the updates
     df = tickstore_lib.read('SYM', columns=('a',), date_range=dr, include_images=True)
     assert set(df.columns) == set(('a',))
-    assert_array_equal(df['a'].values, np.array([37, 1, np.nan]))
+    assert_array_equal(df['a'].values, np.array([37, 1]))
     assert df.index[0] == dt(2013, 1, 1, 10, tzinfo=mktz('Europe/London'))
     assert df.index[1] == dt(2013, 1, 1, 11, tzinfo=mktz('Europe/London'))
-    assert df.index[2] == dt(2013, 1, 1, 12, tzinfo=mktz('Europe/London'))
 
     # Read just the image column
     df = tickstore_lib.read('SYM', columns=['c'], date_range=dr, include_images=True)
     assert set(df.columns) == set(['c'])
-    assert_array_equal(df['c'].values, np.array([2, np.nan, np.nan]))
+    assert_array_equal(df['c'].values, np.array([2]))
     assert df.index[0] == dt(2013, 1, 1, 10, tzinfo=mktz('Europe/London'))
-    assert df.index[1] == dt(2013, 1, 1, 11, tzinfo=mktz('Europe/London'))
-    assert df.index[2] == dt(2013, 1, 1, 12, tzinfo=mktz('Europe/London'))


### PR DESCRIPTION
By using the index bitfield masks we can return a sparse dataframe.

This is a behaviour change, as we don't return rows for timestamps where
the field wasn't updated.

Old code:
=========

```
# All columns
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206))
1 loops, best of 3: 1.99 s per loop

# Multiple columns
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206),
columns=['DISC_BID1', 'BID'])
10 loops, best of 3: 82.2 ms per loop

# Single very sparse column
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206),
columns=['DISC_BID1'])
10 loops, best of 3: 76.4 ms per loop
```

New code:
=========

```
# All columns
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206))
1 loop, best of 3: 2.29 s per loop

# Multiple columns
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206),
columns=['DISC_BID1', 'BID'])
10 loops, best of 3: 75.4 ms per loop

# Single very sparse column
%timeit l.read('3284.JP', date_range=adu.DateRange(20170101, 20170206),
columns=['DISC_BID1'])
10 loops, best of 3: 47.4 ms per loop
```

Fixes #290
