### PR TITLE
Used <=0.8.2 to fix broken builds in the following cases: using 0.8.2…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
                     ],
     install_requires=["decorator",
                       "enum34",
-                      "lz4==0.8.2",
+                      "lz4<=0.8.2",
                       "mockextras",
                       "pandas",
                       "pymongo>=3.0",


### PR DESCRIPTION
… + the system-installed lz4 libs are older and not contain all symbols. This happens because v0.8.2 has external dependencies for lz4.so on system's libs.