### PR TITLE
Yjiangnan patch 1 for Mac OS X installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,9 @@ from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 from Cython.Build import cythonize
 import six
-import sys, os
-os.environ["CC"] = "g++-6"; os.environ["CXX"] = "g++-6" # gcc-4.2 on Mac OS X does not work with OpenMP
+import sys, os, platform
+if platform.system().lower() == 'darwin':
+    os.environ["CC"] = "g++-6"; os.environ["CXX"] = "g++-6" # gcc-4.2 on Mac OS X does not work with OpenMP
 
 # Convert Markdown to RST for PyPI
 # http://stackoverflow.com/a/26737672

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 from Cython.Build import cythonize
 import six
-import sys
+import sys, os
+os.environ["CC"] = "g++-6"; os.environ["CXX"] = "g++-6" # gcc-4.2 on Mac OS X does not work with OpenMP
 
 # Convert Markdown to RST for PyPI
 # http://stackoverflow.com/a/26737672
@@ -66,7 +67,7 @@ class PyTest(TestCommand):
 # Cython lz4
 compress = Extension('arctic._compress',
                      sources=["src/_compress.pyx", "src/lz4.c", "src/lz4hc.c"],
-                     extra_compile_args=['-fopenmp'],
+                     extra_compile_args=['-fopenmp', '-fpermissive'], # Avoid compiling error with prange. Similar to http://stackoverflow.com/questions/36577182/unable-to-assign-value-to-array-in-prange
                      extra_link_args=['-fopenmp'])
 
 setup(

--- a/src/_compress.pyx
+++ b/src/_compress.pyx
@@ -66,7 +66,7 @@ def compressHC(pString):
     return _compress(pString, LZ4_compressHC)
 
 
-cdef _compress(pString, int (*Fnptr_LZ4_compress)(char *, char *, int)):
+cdef _compress(pString, int (*Fnptr_LZ4_compress)(const char *, char *, int)):
     # sizes
     cdef uint32_t compressed_size
     cdef uint32_t original_size = len(pString)
@@ -141,7 +141,7 @@ def compressarrHC(pStrList):
     return _compressarr(pStrList, LZ4_compressHC)
 
 
-cdef _compressarr(pStrList, int (*Fnptr_LZ4_compress)(char *, char *, int) nogil):
+cdef _compressarr(pStrList, int (*Fnptr_LZ4_compress)(const char *, char *, int) nogil):
     
     if len(pStrList) == 0:
         return []


### PR DESCRIPTION
I fixed some compiling errors on Mac OS X. gcc-4.2 on Mac does not support OpenMP, so g++-6 has to be used.