### PR TITLE
Make concurrent appends safe

### DIFF
--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -211,7 +211,7 @@ class NdarrayStore(object):
         rtn = np.dtype(rtn, metadata=dict(dtype.metadata or {}))
         return rtn
 
-    def append(self, arctic_lib, version, symbol, item, previous_version, dtype=None):
+    def append(self, arctic_lib, version, symbol, item, previous_version, dtype=None, dirty_append=True):
         collection = arctic_lib.get_top_level_collection()
         if previous_version.get('shape', [-1]) != [-1, ] + list(item.shape)[1:]:
             raise UnhandledDtypeException()
@@ -255,9 +255,9 @@ class NdarrayStore(object):
             version['dtype'] = previous_version['dtype']
             version['dtype_metadata'] = previous_version['dtype_metadata']
             version['type'] = self.TYPE
-            self._do_append(collection, version, symbol, item, previous_version)
+            self._do_append(collection, version, symbol, item, previous_version, dirty_append)
 
-    def _do_append(self, collection, version, symbol, item, previous_version):
+    def _do_append(self, collection, version, symbol, item, previous_version, dirty_append):
 
         data = item.tostring()
         # Compatibility with Arctic 1.22.0 that didn't write base_sha into the version document
@@ -274,7 +274,7 @@ class NdarrayStore(object):
 
         #_CHUNK_SIZE is probably too big if we're only appending single rows of data - perhaps something smaller,
         #or also look at number of appended segments?
-        if version['append_count'] < _APPEND_COUNT and version['append_size'] < _APPEND_SIZE:
+        if not dirty_append and version['append_count'] < _APPEND_COUNT and version['append_size'] < _APPEND_SIZE:
             version['base_version_id'] = previous_version.get('base_version_id', previous_version['_id'])
 
             if len(item) > 0:
@@ -318,7 +318,7 @@ class NdarrayStore(object):
         # Figure out which is the last 'full' chunk
         spec = {'symbol': symbol,
                 'parent': previous_version.get('base_version_id', previous_version['_id']),
-                'segment': {'$lt': version['up_to']}}
+                'segment': {'$lt': previous_version['up_to']}}
 
         read_index_range = [0, None]
         # The unchanged segments are those not yet compressed
@@ -345,6 +345,7 @@ class NdarrayStore(object):
         if unchanged_segment_ids:
             read_index_range[0] = unchanged_segment_ids[-1]['segment'] + 1
 
+        # Only read back the section that needs to be compressed here (index_range=...)
         old_arr = self._do_read(collection, previous_version, symbol, index_range=read_index_range)
         if len(item) == 0:
             logger.debug('Rewrite and compress/chunk item %s, rewrote old_arr' % symbol)
@@ -404,8 +405,9 @@ class NdarrayStore(object):
         if previous_version:
             if 'sha' in previous_version \
                     and self.checksum(item[:previous_version['up_to']]) == previous_version['sha']:
-                #The first n rows are identical to the previous version, so just append.
-                self._do_append(collection, version, symbol, item[previous_version['up_to']:], previous_version)
+                # The first n rows are identical to the previous version, so just append.
+                # Do a 'dirty' append (i.e. concat & start from a new base version) for safety
+                self._do_append(collection, version, symbol, item[previous_version['up_to']:], previous_version, dirty_append=True)
                 return
 
         version['base_sha'] = version['sha']

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -154,9 +154,9 @@ class PandasSeriesStore(PandasStore):
         item, md = self.SERIALIZER.serialize(item)
         super(PandasSeriesStore, self).write(arctic_lib, version, symbol, item, previous_version, dtype=md)
 
-    def append(self, arctic_lib, version, symbol, item, previous_version):
+    def append(self, arctic_lib, version, symbol, item, previous_version, **kwargs):
         item, md = self.SERIALIZER.serialize(item)
-        super(PandasSeriesStore, self).append(arctic_lib, version, symbol, item, previous_version, dtype=md)
+        super(PandasSeriesStore, self).append(arctic_lib, version, symbol, item, previous_version, dtype=md, **kwargs)
 
     def read(self, arctic_lib, version, symbol, **kwargs):
         item = super(PandasSeriesStore, self).read(arctic_lib, version, symbol, **kwargs)
@@ -178,9 +178,9 @@ class PandasDataFrameStore(PandasStore):
         item, md = self.SERIALIZER.serialize(item)
         super(PandasDataFrameStore, self).write(arctic_lib, version, symbol, item, previous_version, dtype=md)
 
-    def append(self, arctic_lib, version, symbol, item, previous_version):
+    def append(self, arctic_lib, version, symbol, item, previous_version, **kwargs):
         item, md = self.SERIALIZER.serialize(item)
-        super(PandasDataFrameStore, self).append(arctic_lib, version, symbol, item, previous_version, dtype=md)
+        super(PandasDataFrameStore, self).append(arctic_lib, version, symbol, item, previous_version, dtype=md, **kwargs)
 
     def read(self, arctic_lib, version, symbol, **kwargs):
         item = super(PandasDataFrameStore, self).read(arctic_lib, version, symbol, **kwargs)
@@ -220,5 +220,5 @@ class PandasPanelStore(PandasDataFrameStore):
             return item.iloc[:, 0].unstack().to_panel()
         return item.to_panel()
 
-    def append(self, arctic_lib, version, symbol, item, previous_version):
+    def append(self, arctic_lib, version, symbol, item, previous_version, **kwargs):
         raise ValueError('Appending not supported for pandas.Panel')

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -474,17 +474,18 @@ class VersionStore(object):
         assert previous_version is not None
         dirty_append = False
 
-        # Take a version number for the append.
-        # If the version numbers aren't in line, then we've either had a failed append in the past,
-        # we're in the midst of a concurrent update, we've deleted a version and are somehow 'forking' history
+        # Take a version number for this append.
+        # If the version numbers of this and the previous version aren't sequential,
+        # then we've either had a failed append in the past,
+        # we're in the midst of a concurrent update, we've deleted a version in-between
+        # or are somehow 'forking' history
         next_ver = self._version_nums.find_one_and_update({'symbol': symbol, },
                                                           {'$inc': {'version': 1}},
                                                           upsert=False, new=True)['version']
         if next_ver != previous_version['version'] + 1:
             dirty_append = True
-            logger.error('''version_nums is out of sync with previous version document.
-            This probably means that either a version document write has previously failed, or the previous version has been deleted.
-            There will be a gap in the data.''')
+            logger.debug('''version_nums is out of sync with previous version document.
+            This probably means that either a version document write has previously failed, or the previous version has been deleted.''')
 
         # if the symbol has previously been deleted then overwrite
         previous_metadata = previous_version.get('metadata', None)

--- a/tests/integration/test_concurrent_append.py
+++ b/tests/integration/test_concurrent_append.py
@@ -1,0 +1,81 @@
+from arctic.exceptions import OptimisticLockException
+from datetime import datetime, timedelta
+from pandas.core.frame import DataFrame
+import time
+import random
+from multiprocessing import Process, Semaphore
+from arctic.arctic import Arctic
+
+
+class Appender(object):
+
+    def __init__(self, mongo_server, library_name, sem, counter_init, runtime=30):
+        super(Appender, self).__init__()
+        self.lib = Arctic(mongo_server)[library_name]
+        self.sem = sem
+        self.begin = counter_init
+        self.last = counter_init
+        self.timeout = datetime.now() + timedelta(seconds=runtime)
+
+    def run(self):
+        self.sem.acquire()
+        while datetime.now() < self.timeout:
+            try:
+                # Randomy length dataframe to keep appending to
+                df = DataFrame({'v': [self.last]}, [datetime.now()])
+                for i in range(random.randint(1, 10)):
+                    df = df.append(DataFrame({'v': [self.last + i]}, [datetime.now()]))
+                self.last + i
+                df.index.name = 'index'
+                self.lib.append('symbol', df)
+                assert self.last in self.lib.read('symbol').data['v'].tolist()
+                self.last += 2
+            except OptimisticLockException:
+                # Concurrent write, not successful
+                pass
+#             time.sleep(self.begin)
+
+    def check_written_data_exists(self):
+        values = self.lib.read('symbol').data['v'].tolist()
+        assert len(set(values)) == len(values), "Written: %s" % values
+        i = self.begin
+        while i < self.last:
+            assert i in values, "Missing %s in %s" % (i, values)
+            i += 2
+
+
+def test_append_kill(library, mongo_host, library_name):
+    # Empty DF to start
+    df = DataFrame({'v': []}, [])
+    df.index.name = 'index'
+    library.write('symbol', df)
+
+    sem = Semaphore(0)
+
+    def run_append(end):
+        app_1 = Appender(mongo_host, library_name, sem, 0, end)
+        proc = Process(target=app_1.run)
+        proc.start()
+        sem.release()
+        return proc
+
+    def check_written():
+        sym = library.read('symbol')
+        print "Checking written %d" % len(sym.data)
+
+    # time how long it takes to do an append operation
+    start = datetime.now()
+    proc = run_append(1)
+    proc.join()
+    check_written()
+    time_taken = (datetime.now() - start).total_seconds()
+
+    for i in xrange(100):
+        print "Loop %d" % i
+        proc = run_append(100)
+        # kill it randomly
+        time.sleep(2 * (random.random() * time_taken))
+        # Forcibly kill it
+        proc.terminate()
+        # Check we can read the data
+        check_written()

--- a/tests/integration/test_concurrent_append.py
+++ b/tests/integration/test_concurrent_append.py
@@ -70,7 +70,7 @@ def test_append_kill(library, mongo_host, library_name):
     check_written()
     time_taken = (datetime.now() - start).total_seconds()
 
-    for i in xrange(100):
+    for i in range(100):
         print("Loop %d" % i)
         proc = run_append(100)
         # kill it randomly

--- a/tests/integration/test_concurrent_append.py
+++ b/tests/integration/test_concurrent_append.py
@@ -61,7 +61,7 @@ def test_append_kill(library, mongo_host, library_name):
 
     def check_written():
         sym = library.read('symbol')
-        print "Checking written %d" % len(sym.data)
+        print("Checking written %d" % len(sym.data))
 
     # time how long it takes to do an append operation
     start = datetime.now()
@@ -71,7 +71,7 @@ def test_append_kill(library, mongo_host, library_name):
     time_taken = (datetime.now() - start).total_seconds()
 
     for i in xrange(100):
-        print "Loop %d" % i
+        print("Loop %d" % i)
         proc = run_append(100)
         # kill it randomly
         time.sleep(2 * (random.random() * time_taken))

--- a/tests/unit/store/test_ndarray_store.py
+++ b/tests/unit/store/test_ndarray_store.py
@@ -75,12 +75,13 @@ def test_promote_dtype_throws_if_column_is_removed():
 def test_concat_and_rewrite_checks_chunk_count():
     self = create_autospec(NdarrayStore)
     collection = create_autospec(Collection)
-    version = {'up_to': sentinel.up_to}
+    version = {}
     previous_version = {'_id': sentinel.id,
                         'base_version_id': sentinel.base_version_id,
                         'version': sentinel.version,
                         'segment_count' : 3,
-                        'append_count' : 1}
+                        'append_count' : 1,
+                        'up_to': sentinel.up_to}
     symbol = sentinel.symbol
     item = sentinel.item
 
@@ -95,9 +96,9 @@ def test_concat_and_rewrite_checks_written():
     self = create_autospec(NdarrayStore)
     collection = create_autospec(Collection)
     version = {'_id': sentinel.version_id,
-               'up_to': sentinel.up_to,
                'segment_count': 1}
     previous_version = {'_id': sentinel.id,
+                       'up_to': sentinel.up_to,
                         'base_version_id': sentinel.base_version_id,
                         'version': sentinel.version,
                         'segment_count' : 5,
@@ -119,9 +120,9 @@ def test_concat_and_rewrite_checks_updated():
     self = create_autospec(NdarrayStore)
     collection = create_autospec(Collection)
     version = {'_id': sentinel.version_id,
-               'up_to': sentinel.up_to,
                'segment_count': 1}
     previous_version = {'_id': sentinel.id,
+                        'up_to': sentinel.up_to,
                         'base_version_id': sentinel.base_version_id,
                         'version': sentinel.version,
                         'segment_count' : 5,


### PR DESCRIPTION
Make concurrent appends safe(r) by introduce a 'dirty_append' kwarg to the append() method. 

Any time an append may not be completely sequential with the previous version, it is flagged as 'dirty' and we make it multiprocess safe by concatenating and rewriting any previously appended chunks.