### PR TITLE
$size queries can't use indexes, use alternative queries.

### DIFF
--- a/arctic/store/_version_store_utils.py
+++ b/arctic/store/_version_store_utils.py
@@ -52,9 +52,7 @@ def cleanup(arctic_lib, symbol, version_ids):
     for v in version_ids:
         # Remove all documents which only contain the parent
         collection.delete_many({'symbol': symbol,
-                               'parent': {'$all': [v],
-                                          '$size': 1},
-                               })
+                               'parent': [v]})
         # Pull the parent from the parents field
         collection.update_many({'symbol': symbol,
                                 'parent': v},
@@ -62,7 +60,7 @@ def cleanup(arctic_lib, symbol, version_ids):
 
     # Now remove all chunks which aren't parented - this is unlikely, as they will
     # have been removed by the above
-    collection.delete_one({'symbol':  symbol, 'parent': {'$size': 0}})
+    collection.delete_one({'symbol':  symbol, 'parent': []})
 
 
 def _define_compat_pickle_load():

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -588,7 +588,7 @@ class VersionStore(object):
         versions = list(versions_find({  # Find versions of this symbol
                                        'symbol': symbol,
                                        # Not snapshotted
-                                       '$or': [{'parent': {'$exists': False}}, {'parent': {'$size': 0}}],
+                                       '$or': [{'parent': {'$exists': False}}, {'parent': []}],
                                        # At least 'keep_mins' old
                                        '_id': {'$lt': bson.ObjectId.from_datetime(
                                                         dt.utcnow()

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -177,7 +177,7 @@ def test_prune_previous_versions_0_timeout():
     assert self._versions.with_options.call_args_list == [call(read_preference=ReadPreference.PRIMARY)]
     assert self._versions.with_options.return_value.find.call_args_list == [
                                                   call({'$or': [{'parent': {'$exists': False}},
-                                                                {'parent': {'$size': 0}}],
+                                                                {'parent': []}],
                                                         'symbol': sentinel.symbol,
                                                         '_id': {'$lt': bson.ObjectId('524a10810000000000000000')}},
                                                        sort=[('version', -1)],


### PR DESCRIPTION
We've got queries that take over 200 seconds, this makes them much
faster (milliseconds - 5 order of magnitude speedup, yay!).