### PR TITLE
Revert lz4 pinning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install pandas==0.19.2
   - pip install decorator --upgrade
   - pip install enum34 --upgrade
-  - pip install lz4==0.8.2
+  - pip install lz4 --upgrade
   - pip install mock --upgrade
   - pip install mockextras
   - pip install pytest --upgrade

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
                     ],
     install_requires=["decorator",
                       "enum34",
-                      "lz4<=0.8.2",
+                      "lz4",
                       "mockextras",
                       "pandas<=0.19.2",
                       "pymongo>=3.0",


### PR DESCRIPTION
When version 0.9.0 of lz4 was released, it broke arctic, so I pinned arctic to 0.8.2. This broke things internally so It was changed to <= 0.8.2. Now that lz4 latest works with arctic, we should move back to unpinning the version (as it originally was). 