### PR TITLE
Revert LZ4 pin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ install:
   - pip install pandas --upgrade
   - pip install decorator --upgrade
   - pip install enum34 --upgrade
-  - pip install lz4==0.8.2
+  - pip install lz4 --upgrade
   - pip install mock --upgrade
   - pip install mockextras
   - pip install pytest --upgrade

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ### 1.43
   * Bugfix: #350 remove deprecated pandas calls
+  * Bugfix: #357 new lz4 version support 
 
 ### 1.42 (2017-05-12)
   * Bugfix: #346 fixed daterange subsetting error on very large dateframes in version store

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -644,7 +644,7 @@ class TickStore(object):
         rtn[START] = start
 
         logger.warning("NB treating all values as 'exists' - no longer sparse")
-        rowmask = Binary(lz4.compressHC(np.packbits(np.ones(len(df), dtype='uint8'))))
+        rowmask = Binary(lz4.compressHC(np.packbits(np.ones(len(df), dtype='uint8')).tostring()))
 
         index_name = df.index.names[0] or "index"
         recs = df.to_records(convert_datetime64=False)

--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ setup(
                     ],
     install_requires=["decorator",
                       "enum34",
-                      "lz4<=0.8.2",
+                      "lz4",
                       "mockextras",
                       "pandas",
                       "pymongo>=3.0",


### PR DESCRIPTION
revert pin plus fix an instance where a numpy array was not being converted to string/bytes (not sure how it worked before, but it doesnt work with the new version of lz4 since it checks types)