### PR TITLE
Remove replace_many, and fix replace_one

### DIFF
--- a/arctic/store/bson_store.py
+++ b/arctic/store/bson_store.py
@@ -120,6 +120,17 @@ class BSONStore(object):
         return self._collection.find_one_and_replace(filter, replacement, **kwargs)
 
     @mongo_retry
+    def bulk_write(self, requests, **kwargs):
+        """
+        See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.bulk_write
+
+        Warning: this is wrapped in mongo_retry, and is therefore potentially unsafe if the write you want to execute
+        isn't idempotent.
+        """
+        self._arctic_lib.check_quota()
+        return self._collection.bulk_write(requests, **kwargs)
+
+    @mongo_retry
     def count(self, filter, **kwargs):
         """
         See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.count

--- a/arctic/store/bson_store.py
+++ b/arctic/store/bson_store.py
@@ -109,15 +109,7 @@ class BSONStore(object):
         See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.replace_one
         """
         self._arctic_lib.check_quota()
-        return self._collection.update_one(filter, replacement, **kwargs)
-
-    @mongo_retry
-    def replace_many(self, filter, replacement, **kwargs):
-        """
-        See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.replace_many
-        """
-        self._arctic_lib.check_quota()
-        return self._collection.replace_many(filter, replacement, **kwargs)
+        return self._collection.replace_one(filter, replacement, **kwargs)
 
     @mongo_retry
     def find_one_and_replace(self, filter, replacement, **kwargs):

--- a/tests/unit/store/test_bson_store.py
+++ b/tests/unit/store/test_bson_store.py
@@ -57,6 +57,19 @@ def test_insert_many():
     assert collection.insert_many.call_args_list == [call(sentinel.documents)]
 
 
+def test_replace_one():
+    arctic_lib = create_autospec(ArcticLibraryBinding, instance=True)
+    collection = create_autospec(Collection, instance=True)
+    arctic_lib.get_top_level_collection.return_value = collection
+
+    bsons = BSONStore(arctic_lib)
+    bsons.replace_one(sentinel.filter, sentinel.replacement)
+
+    assert arctic_lib.check_quota.call_count == 1
+    assert collection.replace_one.call_count == 1
+    assert collection.replace_one.call_args_list == [call(sentinel.filter, sentinel.replacement)]
+
+
 def test_update_one():
     arctic_lib = create_autospec(ArcticLibraryBinding, instance=True)
     collection = create_autospec(Collection, instance=True)

--- a/tests/unit/store/test_bson_store.py
+++ b/tests/unit/store/test_bson_store.py
@@ -109,6 +109,19 @@ def test_find_one_and_replace():
     assert collection.find_one_and_replace.call_args_list == [call(sentinel.filter, sentinel.replacement)]
 
 
+def test_bulk_write():
+    arctic_lib = create_autospec(ArcticLibraryBinding, instance=True)
+    collection = create_autospec(Collection, instance=True)
+    arctic_lib.get_top_level_collection.return_value = collection
+
+    bsons = BSONStore(arctic_lib)
+    bsons.bulk_write(sentinel.requests)
+
+    assert arctic_lib.check_quota.call_count == 1
+    assert collection.bulk_write.call_count == 1
+    assert collection.bulk_write.call_args_list == [call(sentinel.requests)]
+
+
 def test_delete_one():
     arctic_lib = create_autospec(ArcticLibraryBinding, instance=True)
     collection = create_autospec(Collection, instance=True)


### PR DESCRIPTION
The dreadful consequences of mindless copy-pasting. Mea culpa.