### PR TITLE
fix issue #372

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.48
+  * Bugfix:  #372 OSX build improvements
+
 ### 1.47 (2017-06-19)
   * Feature: Re-introduce #363 `concat` flag, essentially undo-ing 1.45
   * BugFix: #377 Fix broken `replace_one` on BSONStore and add `bulk_write`

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ Arctic currently works with:
  * MongoDB >= 2.4.x
 
 
+Operating Systems:
+ * Linux
+ * macOS
+
 ## Acknowledgements
 
 Arctic has been under active development at [Man AHL](http://www.ahl.com/) since 2012.

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,19 @@ from setuptools import find_packages
 from setuptools.command.test import test as TestCommand
 from Cython.Build import cythonize
 import sys, os, platform
+
+
 if platform.system().lower() == 'darwin':
-    # gcc-4.2 on Mac OS X does not work with OpenMP
-    os.environ["CC"] = "g++-6"; os.environ["CXX"] = "g++-6"
+    # clang on macOS does not work with OpenMP
+    ccs = ["/usr/local/bin/g++-5", "/usr/local/bin/g++-6", "/usr/local/bin/g++-7"]
+    cc = None
+    for compiler in ccs:
+        if os.path.isfile(compiler):
+            cc = compiler
+    if cc is None:
+        raise ValueError("You must install gcc/g++. You can install with homebrew: brew install gcc --without-multilib")
+    os.environ["CC"] = cc
+    os.environ["CXX"] = cc
     # not all OSX/clang compiler flags supported by GCC. For some reason
     # these sometimes are generated and used. Cython will still add more flags.
     os.environ["CFLAGS"] = "-fno-common -fno-strict-aliasing -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -g -fwrapv -Os"

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if platform.system().lower() == 'darwin':
             cc = compiler
     if cc is None:
         raise ValueError("You must install gcc/g++. You can install with homebrew: brew install gcc --without-multilib")
-    os.environ["CC"] = cc
+    os.environ["CC"] = cc.replace("g++", "gcc")
     os.environ["CXX"] = cc
     # not all OSX/clang compiler flags supported by GCC. For some reason
     # these sometimes are generated and used. Cython will still add more flags.


### PR DESCRIPTION
Previously setup.py assumed you had a specific version of gcc installed. This corrects that and looks for the 3 most recent versions provided by homebrew, as well as issues a reasonable error if none of them exist. 

Also updates the README with information about macOS support