### PR TITLE
Fix issue #384

### DIFF
--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -149,7 +149,7 @@ class ChunkStore(object):
             self._collection.delete_many(query)
             self._symbols.delete_many(query)
             self._mdata.delete_many(query)
-        
+
         if audit is not None:
             audit['symbol'] = symbol
             if chunk_range is not None:
@@ -157,7 +157,7 @@ class ChunkStore(object):
                 audit['action'] = 'range delete'
             else:
                 audit['action'] = 'symbol delete'
-            
+
             self._audit.insert_one(audit)
 
     def list_symbols(self, partial_match=None):
@@ -215,7 +215,7 @@ class ChunkStore(object):
             audit['action'] = 'symbol rename'
             audit['old_symbol'] = from_symbol
             self._audit.insert_one(audit)
-        
+
 
     def read(self, symbol, chunk_range=None, filter_data=True, **kwargs):
         """
@@ -245,7 +245,7 @@ class ChunkStore(object):
             raise NoDataFoundException('No data found for %s' % (symbol))
 
         spec = {SYMBOL: symbol,
-                }
+               }
 
         if chunk_range is not None:
             spec.update(CHUNKER_MAP[sym[CHUNKER]].to_mongo(chunk_range))
@@ -270,16 +270,16 @@ class ChunkStore(object):
         if not filter_data or chunk_range is None:
             return data
         return CHUNKER_MAP[sym[CHUNKER]].filter(data, chunk_range)
-    
+
     def read_audit_log(self, symbol=None):
         """
         Reads the audit log
-        
+
         Parameters
         ----------
         symbol: str
             optionally only retrieve specific symbol's audit information
-            
+
         Returns
         -------
         list of dicts
@@ -578,12 +578,12 @@ class ChunkStore(object):
     def read_metadata(self, symbol):
         '''
         Reads user defined metadata out for the given symbol
-        
+
         Parameters
         ----------
         symbol: str
             symbol for the given item in the DB
-        
+
         Returns
         -------
         ?
@@ -720,7 +720,7 @@ class ChunkStore(object):
         res['metadata'] = db.command('collstats', self._mdata.name)
         res['totals'] = {'count': res['chunks']['count'],
                          'size': res['chunks']['size'] + res['symbols']['size'] + res['metadata']['size'],
-                         }
+                        }
         return res
 
     def has_symbol(self, symbol):

--- a/arctic/chunkstore/date_chunker.py
+++ b/arctic/chunkstore/date_chunker.py
@@ -69,7 +69,7 @@ class DateChunker(Chunker):
         -------
         string
         """
-        return chunk_id.strftime("%Y-%m-%d").encode('ascii')
+        return str(chunk_id).encode('ascii')
 
     def to_mongo(self, range_obj):
         """

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -1133,9 +1133,9 @@ def test_get_chunk_range(chunkstore_lib):
     chunkstore_lib.write('test_df', df, chunk_size='D')
     x = list(chunkstore_lib.get_chunk_ranges('test_df'))
     assert(len(x) == 3)
-    assert((b'2016-01-01', b'2016-01-01') in x)
-    assert((b'2016-01-02', b'2016-01-02') in x)
-    assert((b'2016-01-03', b'2016-01-03') in x)
+    assert((b'2016-01-01 00:00:00', b'2016-01-01 23:59:59.999000') in x)
+    assert((b'2016-01-02 00:00:00', b'2016-01-02 23:59:59.999000') in x)
+    assert((b'2016-01-03 00:00:00', b'2016-01-03 23:59:59.999000') in x)
 
 
 def test_iterators(chunkstore_lib):
@@ -1324,7 +1324,7 @@ def test_audit(chunkstore_lib):
 
 
 def test_chunkstore_misc(chunkstore_lib):
-    
+
     p = pickle.dumps(chunkstore_lib)
     c = pickle.loads(p)
     assert(chunkstore_lib._arctic_lib.get_name() == c._arctic_lib.get_name())

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -1,0 +1,25 @@
+"""
+Unit tests for bugfixes
+"""
+
+from datetime import datetime
+
+import pandas as pd
+from pandas import DataFrame
+from pandas.tseries.index import DatetimeIndex
+
+
+# Issue 384
+def test_write_dataframe(chunkstore_lib):
+    # Create dataframe of time measurements taken every 6 hours
+    date_range = pd.date_range(start=datetime(2017, 5, 1, 1), periods=8, freq='6H')
+
+    df = DataFrame(data={'something': [100, 200, 300, 400, 500, 600, 700, 800]},
+                   index=DatetimeIndex(date_range, name='date'))
+
+
+    chunkstore_lib.write('test', df, chunk_size='D')
+
+    # Iterate
+    for chunk in chunkstore_lib.iterator('test'):
+        assert(len(chunk) > 0)

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -5,8 +5,7 @@ Unit tests for bugfixes
 from datetime import datetime
 
 import pandas as pd
-from pandas import DataFrame
-from pandas.tseries.index import DatetimeIndex
+from pandas import DataFrame, DatetimeIndex
 
 
 # Issue 384


### PR DESCRIPTION
Chunkstore was omitting the start and end times of chunks when converting the chunk sentinels to strings. This fixes that behavior and allows it to work with dates as well as datetimes. 