### PR TITLE
Renaming libraries within a database/namespace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 1.49
   * Bugfix:  #384 sentinels missing time data on chunk start/ends in ChunkStore
   * Bugfix:  #382 Remove dependency on cython being pre-installed
+  * Bugfix:  #343 Renaming libraries/collections within a namespace/database
   
 ### 1.48 (2017-06-26)
   * BugFix: Rollback #363, as it breaks multi-index dataframe

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -322,13 +322,21 @@ class Arctic(object):
         to_lib: str
             The new name of the library
         """
+        to_colname = to_lib
+        if '.' in from_lib and '.' in to_lib:
+            if from_lib.split('.')[0] != to_lib.split('.')[0]:
+                raise ValueError("Collection can only be renamed in the same database")
+            to_colname = to_lib.split('.')[1]
+
         l = ArcticLibraryBinding(self, from_lib)
         colname = l.get_top_level_collection().name
-        logger.info('Dropping collection: %s' % colname)
-        l._db[colname].rename(to_lib)
+
+        logger.info('Renaming collection: %s' % colname)
+        l._db[colname].rename(to_colname)
         for coll in l._db.collection_names():
             if coll.startswith(colname + '.'):
-                l._db[coll].rename(coll.replace(from_lib, to_lib))
+                l._db[coll].rename(coll.replace(colname, to_colname))
+
         if from_lib in self._library_cache:
             del self._library_cache[from_lib]
             del self._library_cache[l.get_name()]

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -168,6 +168,25 @@ def test_lib_rename(arctic):
     assert('test' not in arctic.list_libraries())
 
 
+def test_lib_rename_namespace(arctic):
+    arctic.initialize_library('namespace.test')
+    l = arctic['namespace.test']
+    l.write('test_data', 'abc')
+
+    with pytest.raises(ValueError) as e:
+        arctic.rename_library('namespace.test', 'new_namespace.test')
+    assert('Collection can only be renamed in the same database' in str(e))
+
+    arctic.rename_library('namespace.test', 'namespace.newlib')
+    l = arctic['namespace.newlib']
+    assert(l.read('test_data').data == 'abc')
+
+    with pytest.raises(LibraryNotFoundException) as e:
+        l = arctic['namespace.test']
+    assert('Library namespace.test' in str(e))
+    assert('namespace.test' not in arctic.list_libraries())
+
+
 def test_lib_type(arctic):
     arctic.initialize_library('test')
     assert(arctic.get_library_type('test') == VERSION_STORE)


### PR DESCRIPTION
Previously this did not work, you could only rename libraries named "test", a library named "test.test" was not renameable. 


see #343 