### PR TITLE
Handle case where appending to empty array fails in _concat_and_rewrite.

### DIFF
--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -331,7 +331,8 @@ class NdarrayStore(object):
             # We want to stop iterating when we find the first uncompressed chunks
             if not segment['compressed']:
                 # We include the last chunk in the recompression
-                unchanged_segment_ids.pop()
+                if unchanged_segment_ids:
+                    unchanged_segment_ids.pop()
                 break
             unchanged_segment_ids.append(segment)
 

--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -957,3 +957,19 @@ def test_date_range_large(library):
     library.write('test', df)
     r = library.read('test', date_range=DateRange(dt(2017,1,1), dt(2017,1,2)))
     assert_frame_equal(df, r.data)
+
+
+def test_append_after_empty(library):
+    len_df = 500
+    index = [dt(2017, 1, 2)] * len_df
+    data = np.random.random((len_df, 10))
+    df = pd.DataFrame(index=index, data=data)
+    df.index.name = 'index'
+    df.columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+    library.write(symbol, df.iloc[:0])
+
+    for i in range(len_df):
+        library.append(symbol, df.iloc[i:i + 1])
+    r = library.read(symbol)
+    assert_frame_equal(df, r.data)
+


### PR DESCRIPTION
If we append to an empty array, we can end up with a situation where there are uncompressed chunks, but no compressed chunks. This causes _concat_and_rewrite to blow up when compressing the uncompressed data. 