### PR TITLE
Memory optimisation

### DIFF
--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -62,7 +62,7 @@ class PandasSerializer(object):
 
     def _index_from_records(self, recarr):
         index = recarr.dtype.metadata['index']
-        rtn = MultiIndex.from_arrays([recarr[str(i)] for i in index], names=index)
+        rtn = MultiIndex.from_arrays([np.copy(recarr[str(i)]) for i in index], names=index)
 
         if isinstance(rtn, DatetimeIndex) and 'index_tz' in recarr.dtype.metadata:
             rtn = rtn.tz_localize('UTC').tz_convert(recarr.dtype.metadata['index_tz'])

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -191,6 +191,9 @@ class NdarrayStore(object):
 
         data = b''.join(segments)
 
+        # free up memory from initial copy of data
+        del segments
+
         # Check that the correct number of segments has been returned
         if segment_count is not None and i + 1 != segment_count:
             raise OperationFailure("Incorrect number of segments returned for {}:{}.  Expected: {}, but got {}. {}".format(


### PR DESCRIPTION
When looking at the memory usage deserialising large pandas dataframes then it became clear that the dataframes were taking more memory than they needed, roughly double.  
We have a df 2000 by 100000 with integer index and float64 data, this took around 2.6GB, but ask pandas how big it is and it reports 1.3GB. It came down to two copies of the data being held for each dataframe.  There was a bug to do with view vs copies of ndarrays that meant one copy of the entire ndarray (including the index) was being held by the multi-index and another copy of the data part of the array was being held by the dataframe.