### PR TITLE
remove python 3.5 from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 language: python
 python:
   - "2.7"
-  - "3.5"
   - "3.6"
 
 addons:


### PR DESCRIPTION
Arctic has no python3 exclusive features, much less anything exclusive to 3.6 over 3.5. No reason have increased build times by running on two 3.X versions, especially now that 3.5 is bugfix only