### PR TITLE
fix date chunker so it respects intervals

### DIFF
--- a/arctic/chunkstore/date_chunker.py
+++ b/arctic/chunkstore/date_chunker.py
@@ -1,7 +1,7 @@
 import pandas as pd
 
 from ._chunker import Chunker, START, END
-from ..date import DateRange
+from arctic.date import DateRange, to_pandas_closed_closed
 
 
 class DateChunker(Chunker):
@@ -107,15 +107,20 @@ class DateChunker(Chunker):
         """
         if isinstance(range_obj, (pd.DatetimeIndex, tuple)):
             range_obj = DateRange(range_obj[0], range_obj[-1])
+
+        range_obj = to_pandas_closed_closed(range_obj, add_tz=False)
+        start = range_obj.start
+        end = range_obj.end
+
         if 'date' in data.index.names:
-            return data[range_obj.start:range_obj.end]
+            return data[start:end]
         elif 'date' in data.columns:
-            if range_obj.start and range_obj.end:
-                return data[(data.date >= range_obj.start) & (data.date <= range_obj.end)]
-            elif range_obj.start:
-                return data[(data.date >= range_obj.start)]
-            elif range_obj.end:
-                return data[(data.date <= range_obj.end)]
+            if start and end:
+                return data[(data.date >= start) & (data.date <= end)]
+            elif start:
+                return data[(data.date >= start)]
+            elif end:
+                return data[(data.date <= end)]
             else:
                 return data
         else:

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -2,18 +2,19 @@
 Unit tests for bugfixes
 """
 
-from datetime import datetime
+from datetime import datetime as dt
 
 import pandas as pd
 from pandas import DataFrame, DatetimeIndex
 from pandas.util.testing import assert_frame_equal
 import numpy as np
-import time
+from arctic.date import DateRange, CLOSED_OPEN, CLOSED_CLOSED, OPEN_OPEN, OPEN_CLOSED
+
 
 # Issue 384
 def test_write_dataframe(chunkstore_lib):
     # Create dataframe of time measurements taken every 6 hours
-    date_range = pd.date_range(start=datetime(2017, 5, 1, 1), periods=8, freq='6H')
+    date_range = pd.date_range(start=dt(2017, 5, 1, 1), periods=8, freq='6H')
 
     df = DataFrame(data={'something': [100, 200, 300, 400, 500, 600, 700, 800]},
                    index=DatetimeIndex(date_range, name='date'))
@@ -54,3 +55,43 @@ def test_compression(chunkstore_lib):
     chunkstore_lib.append('test', df2)
     read = chunkstore_lib.read('test')
     assert_frame_equal(read, pd.concat([df, df2], ignore_index=True))
+
+
+# issue #420 - ChunkStore doesnt respect DateRange interval
+def test_date_interval(chunkstore_lib):
+    date_range = pd.date_range(start=dt(2017, 5, 1), periods=8, freq='D')
+
+    df = DataFrame(data={'data': range(8)},
+                   index=DatetimeIndex(date_range, name='date'))
+
+
+    # test with index
+    chunkstore_lib.write('test', df, chunk_size='D')
+
+    ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), CLOSED_OPEN))
+    assert_frame_equal(ret, df[1:4])
+    ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), OPEN_OPEN))
+    assert_frame_equal(ret, df[2:4])
+    ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), OPEN_CLOSED))
+    assert_frame_equal(ret, df[2:5])
+    ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), CLOSED_CLOSED))
+    assert_frame_equal(ret, df[1:5])
+    ret = chunkstore_lib.read('test', chunk_range=DateRange(dt(2017,5,2), None, CLOSED_OPEN))
+    assert_frame_equal(ret, df[1:8])
+
+    # test without index
+    df = DataFrame(data={'data': range(8),
+                         'date': date_range})
+
+    chunkstore_lib.write('test2', df, chunk_size='D')
+
+    ret = chunkstore_lib.read('test2', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), CLOSED_OPEN))
+    assert(len(ret) == 3)
+    ret = chunkstore_lib.read('test2', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), OPEN_OPEN))
+    assert(len(ret) == 2)
+    ret = chunkstore_lib.read('test2', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), OPEN_CLOSED))
+    assert(len(ret) == 3)
+    ret = chunkstore_lib.read('test2', chunk_range=DateRange(dt(2017,5,2), dt(2017,5,5), CLOSED_CLOSED))
+    assert(len(ret) == 4)
+    ret = chunkstore_lib.read('test2', chunk_range=DateRange(dt(2017,5,2), None, CLOSED_OPEN))
+    assert(len(ret) == 7)


### PR DESCRIPTION
date chunker in chunkstore does not currently respect open intervals from date range when filtering data frames by user supplied chunk_range