### PR TITLE
Fix read of empty MultiIndex+tz Series

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.54 (2017-10-18)
+  * Bugfix:  #440 Fix read empty MultiIndex+tz Series
+
 ### 1.53 (2017-10-06)
   * Perf:    #408 Improve memory performance of version store's serializer
   * Bugfix   #394 Multi symbol read in chunkstore

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -127,6 +127,14 @@ def test_save_read_pandas_dataframe_with_datetimeindex_with_timezone(library):
     assert all(df.index == saved_df.index)
 
 
+def test_save_read_pandas_empty_series_with_datetime_multiindex_with_timezone(library):
+    empty_index = pd.MultiIndex(levels=(pd.DatetimeIndex([], tz="America/Chicago"), pd.Index([])), labels=([], []))
+    df = Series(data=[], index=empty_index)
+    library.write('pandas', df)
+    saved_df = library.read('pandas').data
+    assert empty_index.equal_levels(saved_df.index), "Index timezone information should be maintained, even when empty"
+
+
 def test_save_read_pandas_dataframe_with_datetimeindex(library):
     df = DataFrame(data=['A', 'BC', 'DEF'], index=np.array([dt(2013, 1, 1),
                                                             dt(2013, 1, 2),
@@ -552,8 +560,8 @@ def test_panel_save_read_with_nans(library):
 
     assert p_in.shape == p_out.shape
     # check_names is False because pandas helpfully names the axes for us.
-    assert_frame_equal(p_in.iloc[0], p_out.iloc[0], check_names=False)  
-    assert_frame_equal(p_in.iloc[1], p_out.iloc[1], check_names=False)  
+    assert_frame_equal(p_in.iloc[0], p_out.iloc[0], check_names=False)
+    assert_frame_equal(p_in.iloc[1], p_out.iloc[1], check_names=False)
 
 
 def test_save_read_ints(library):


### PR DESCRIPTION
It's impossible to determine the dtype of a saved empty index from the saved information alone and pandas has the bad habit of defaulting to either float or int. We can work out whether a MultIndex level is meant to be a DatetimeIndex based on the presence of the separate timezone information. Based on this, we can cast back empty indices to DatetimeIndex where appropriate.

This is only a shim - a good fix would have us saving down all the dtypes for both indices and data. This should ensure that any arbitrary type empty series written out can be read back in as it was.

Fixes #440 