### PR TITLE
Resolve issue 439 cursor timing out

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.55
+  * Bugfix:  #439 fix cursor timeouts in chunkstore iterator
+
 ### 1.54 (2017-10-18)
   * Bugfix:  #440 Fix read empty MultiIndex+tz Series
 

--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -670,7 +670,7 @@ class ChunkStore(object):
 
         c = CHUNKER_MAP[sym[CHUNKER]]
 
-        for chunk in self.get_chunk_ranges(symbol, chunk_range=chunk_range):
+        for chunk in list(self.get_chunk_ranges(symbol, chunk_range=chunk_range)):
             yield self.read(symbol, chunk_range=c.to_range(chunk[0], chunk[1]))
 
     def reverse_iterator(self, symbol, chunk_range=None):
@@ -694,7 +694,7 @@ class ChunkStore(object):
 
         c = CHUNKER_MAP[sym[CHUNKER]]
 
-        for chunk in self.get_chunk_ranges(symbol, chunk_range=chunk_range, reverse=True):
+        for chunk in list(self.get_chunk_ranges(symbol, chunk_range=chunk_range, reverse=True)):
             yield self.read(symbol, chunk_range=c.to_range(chunk[0], chunk[1]))
 
     def stats(self):

--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -3,7 +3,8 @@ import numpy as np
 
 from pandas import DataFrame, MultiIndex, Series, DatetimeIndex, Index
 try:
-    from pandas._libs.tslib import Timestamp, get_timezone
+    from pandas._libs.tslib import Timestamp
+    from pandas._libs.tslibs.timezones import get_timezone
 except ImportError:
     from pandas.tslib import Timestamp, get_timezone
 

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -288,17 +288,16 @@ def test_empty_dataframe_should_ignore_dtype2(library):
 def test_dataframe_append_should_promote_string_column(library):
     data = np.zeros((2,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a10')])
     data[:] = [(1, 2., 'Hello'), (2, 3., "World")]
-    df = DataFrame(data, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                       (np.datetime64(dt(2013, 1, 2)),), ], names=[u'DATETIME']))
+    df = DataFrame(data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                       dt(2013, 1, 2)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     data2 = np.zeros((1,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a30')])
     data2[:] = [(3, 4., 'Hello World - Good Morning')]
-    df2 = DataFrame(data2, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 3)),)], names=[u'DATETIME']))
+    df2 = DataFrame(data2, index=DatetimeIndex(np.array([dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     expected_data = np.zeros((3,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a30')])
     expected_data[:] = [(1, 2., 'Hello'), (2, 3., "World"), (3, 4., 'Hello World - Good Morning')]
-    expected = DataFrame(expected_data, MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                                (np.datetime64(dt(2013, 1, 2)),),
-                                                                (np.datetime64(dt(2013, 1, 3)),)],
-                                                               names=[u'DATETIME']))
+    expected = DataFrame(expected_data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                                       dt(2013, 1, 2),
+                                                                       dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
 
     library.write('pandas', df)
     library.append('pandas', df2)
@@ -310,17 +309,16 @@ def test_dataframe_append_should_promote_string_column(library):
 def test_dataframe_append_should_add_new_column(library):
     data = np.zeros((2,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a10')])
     data[:] = [(1, 2., 'Hello'), (2, 3., "World")]
-    df = DataFrame(data, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                       (np.datetime64(dt(2013, 1, 2)),), ], names=[u'DATETIME']))
+    df = DataFrame(data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                       dt(2013, 1, 2)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     data2 = np.zeros((1,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a10'), ('D', 'f4')])
     data2[:] = [(4, 5., 'Hi', 6.)]
-    df2 = DataFrame(data2, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 3)),)], names=[u'DATETIME']))
+    df2 = DataFrame(data2, index=DatetimeIndex(np.array([dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     expected_data = np.zeros((3,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a10'), ('D', 'f4')])
     expected_data[:] = [(1, 2., 'Hello', np.nan), (2, 3., "World", np.nan), (4, 5., 'Hi', 6.)]
-    expected = DataFrame(expected_data, MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                                (np.datetime64(dt(2013, 1, 2)),),
-                                                                (np.datetime64(dt(2013, 1, 3)),)],
-                                                               names=[u'DATETIME']))
+    expected = DataFrame(expected_data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                                       dt(2013, 1, 2),
+                                                                       dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
 
     library.write('pandas', df)
     library.append('pandas', df2)
@@ -332,18 +330,17 @@ def test_dataframe_append_should_add_new_column(library):
 def test_dataframe_append_should_add_new_columns_and_reorder(library):
     data = np.zeros((2,), dtype=[('A', 'i4'), ('B', 'f4'), ('C', 'a10')])
     data[:] = [(1, 2., 'Hello'), (2, 3., "World")]
-    df = DataFrame(data, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                       (np.datetime64(dt(2013, 1, 2)),), ], names=[u'DATETIME']))
+    df = DataFrame(data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                       dt(2013, 1, 2)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     data2 = np.zeros((1,), dtype=[('C', 'a10'), ('A', 'i4'), ('E', 'a1'), ('B', 'f4'), ('D', 'f4'), ('F', 'i4')])
     data2[:] = [('Hi', 4, 'Y', 5., 6., 7)]
-    df2 = DataFrame(data2, index=MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 3)),)], names=[u'DATETIME']))
+    df2 = DataFrame(data2, index=DatetimeIndex(np.array([dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
     expected_data = np.zeros((3,), dtype=[('C', 'a10'), ('A', 'i4'), ('E', 'a1'),
                                           ('B', 'f4'), ('D', 'f4'), ('F', 'i4')])
     expected_data[:] = [('Hello', 1, '', 2., np.nan, 0), ("World", 2, '', 3., np.nan, 0), ('Hi', 4, 'Y', 5., 6., 7)]
-    expected = DataFrame(expected_data, MultiIndex.from_tuples([(np.datetime64(dt(2013, 1, 1)),),
-                                                                (np.datetime64(dt(2013, 1, 2)),),
-                                                                (np.datetime64(dt(2013, 1, 3)),)],
-                                                               names=[u'DATETIME']))
+    expected = DataFrame(expected_data, index=DatetimeIndex(np.array([dt(2013, 1, 1),
+                                                                       dt(2013, 1, 2),
+                                                                       dt(2013, 1, 3)]).astype('datetime64[ns]'), name=[u'DATETIME']))
 
     library.write('pandas', df)
     library.append('pandas', df2)


### PR DESCRIPTION
Using `iterator` can cause timeouts on the initial cursor that was used to query the dates for the symbol. This fixes that by resolving all the elements in the generator before creating the 2nd cursor. 