### PR TITLE
fix legacy segments - issue-442

### DIFF
--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -79,6 +79,12 @@ class ChunkStore(object):
         # Do we allow reading from secondaries
         self._allow_secondary = self._arctic_lib.arctic._allow_secondary
         self._reset()
+        self._fix_legacy_data()
+
+    def _fix_legacy_data(self):
+        # Issue 442
+        # for legacy data that was incorectly marked with segment start of -1
+        self._collection.update_many({SEGMENT: -1}, {'$set': {SEGMENT: 0}})
 
     @mongo_retry
     def _reset(self):

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -185,3 +185,17 @@ def test_compression_legacy(chunkstore_lib):
 
     read = chunkstore_lib.read('test')
     assert_frame_equal(read, pd.concat([df, df2], ignore_index=True))
+
+    chunkstore_lib._collection.update_one({'sy': 'test', 'sg': 0}, {'$set': {'sg': -1}})
+    chunkstore_lib._collection.update_one({'sy': 'test', 'sg': 1}, {'$set': {'sg': 0}})
+    assert(get_segments() == [-1, 0])
+
+    chunkstore_lib._fix_legacy_data()
+    assert(get_segments() == [-1, 0])
+    
+
+
+
+
+
+

--- a/tests/integration/chunkstore/test_fixes.py
+++ b/tests/integration/chunkstore/test_fixes.py
@@ -145,3 +145,43 @@ def test_iterator(chunkstore_lib):
     chunkstore_lib.write('test', df, chunk_size='A')
     ret = chunkstore_lib.get_chunk_ranges('test')
     assert(len(list(ret)) == 1)
+
+
+def test_compression_legacy(chunkstore_lib):
+    """
+    Issue 442 - Data already written with -1 as the segment needs to be updated on update and appends
+    """
+    def generate_data(date):
+        """
+        Generates a dataframe that is almost exactly the size of
+        a segment in chunkstore
+        """
+        df = pd.DataFrame(np.random.randn(10000*16, 12),
+                          columns=['beta', 'btop', 'earnyild', 'growth', 'industry', 'leverage',
+                                   'liquidty', 'momentum', 'resvol', 'sid', 'size', 'sizenl'])
+        df['date'] = date
+
+        return df
+
+    def get_segments():
+        return chunkstore_lib._collection.distinct('sg', {'sy': 'test'})
+
+    date = pd.Timestamp('2000-01-01')
+    df = generate_data(date)
+    chunkstore_lib.write('test', df, chunk_size='A')
+
+    assert(get_segments() == [0])
+    chunkstore_lib._collection.update_one({'sy': 'test'}, {'$set': {'sg': -1}})
+    assert(get_segments() == [-1])
+
+    chunkstore_lib._fix_legacy_data()
+
+    date += pd.Timedelta(1, unit='D')
+    df2 = generate_data(date)
+
+
+    chunkstore_lib.append('test', df2)
+    assert(get_segments() == [0, 1])
+
+    read = chunkstore_lib.read('test')
+    assert_frame_equal(read, pd.concat([df, df2], ignore_index=True))


### PR DESCRIPTION
previous changes fixed a bug where segments labels started with -1 and we not properly handled when the chunk size increased to more than 1 segment. This introduced a new bug where legacy data with -1 segments would not properly be removed and it would cause decompression errors during a read.


This fixes that by converting all -1 segments to 0 segments at library object instantiation. 