### PR TITLE
Prevent exceptions in check_quota from killing a write

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   * Bugfix:  #450 fix error in chunkstore delete when chunk range produces empty df
   * Bugfix:  #442 fix incorrect segment values in multi segment chunks in chunkstore
   * Feature: #457 enchances fix for #442 via segment_id_repair tool
+  * Bugfix:  #385 exceptions during quota statistics no longer kill a write
 
 ### 1.54 (2017-10-18)
   * Bugfix:  #440 Fix read empty MultiIndex+tz Series

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -495,23 +495,26 @@ class ArcticLibraryBinding(object):
                                          to_gigabytes(self.quota)))
 
         # Quota not exceeded, print an informational message and return
-        avg_size = size // count if count > 1 else 100 * 1024
-        remaining = self.quota - size
-        remaining_count = remaining / avg_size
-        if remaining_count < 100 or float(remaining) / self.quota < 0.1:
-            logger.warning("Mongo Quota: %s %.3f / %.0f GB used" % (
-                            '.'.join([self.database_name, self.library]),
-                            to_gigabytes(size),
-                            to_gigabytes(self.quota)))
-        else:
-            logger.info("Mongo Quota: %s %.3f / %.0f GB used" % (
-                            '.'.join([self.database_name, self.library]),
-                            to_gigabytes(size),
-                            to_gigabytes(self.quota)))
-
-        # Set-up a timer to prevent us for checking for a few writes.
-        # This will check every average half-life
-        self.quota_countdown = int(max(remaining_count // 2, 1))
+        try:
+            avg_size = size // count if count > 1 else 100 * 1024
+            remaining = self.quota - size
+            remaining_count = remaining / avg_size
+            if remaining_count < 100 or float(remaining) / self.quota < 0.1:
+                logger.warning("Mongo Quota: %s %.3f / %.0f GB used" % (
+                                '.'.join([self.database_name, self.library]),
+                                to_gigabytes(size),
+                                to_gigabytes(self.quota)))
+            else:
+                logger.info("Mongo Quota: %s %.3f / %.0f GB used" % (
+                                '.'.join([self.database_name, self.library]),
+                                to_gigabytes(size),
+                                to_gigabytes(self.quota)))
+        
+            # Set-up a timer to prevent us for checking for a few writes.
+            # This will check every average half-life
+            self.quota_countdown = int(max(remaining_count // 2, 1))
+        except Exception as e:
+            logger.warning("Encountered an exception while calculating quota statistics: %s" % str(e))
 
     def get_library_type(self):
         return self.get_library_metadata(ArcticLibraryBinding.TYPE_FIELD)


### PR DESCRIPTION
Since the quota has already been 'checked' we shouldn't letthe generation of informational statistics kill the write