### PR TITLE
Fix the failing integration test due to the Mongo upgrade to 3.6

### DIFF
--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -76,54 +76,55 @@ def test_indexes(arctic):
     c = arctic._conn
     arctic.initialize_library("library", VERSION_STORE, segment='month')
     chunk = c.arctic.library.index_information()
-    assert chunk == {u'_id_': {u'key': [(u'_id', 1)], u'ns': u'arctic.library', u'v': 1},
+    index_version = chunk['_id_']['v']  # Mongo 3.2 has index v1, 3.4 and 3.5 have v2 (3.4 can run in compabitility mode with v1)
+    assert chunk == {u'_id_': {u'key': [(u'_id', 1)], u'ns': u'arctic.library', u'v': index_version},
                              u'symbol_1_parent_1_segment_1': {u'background': True,
                                                               u'key': [(u'symbol', 1),
                                                                        (u'parent', 1),
                                                                        (u'segment', 1)],
                                                               u'ns': u'arctic.library',
                                                               u'unique': True,
-                                                              u'v': 1},
+                                                              u'v': index_version},
                              u'symbol_1_sha_1': {u'background': True,
                                                  u'key': [(u'symbol', 1), (u'sha', 1)],
                                                  u'ns': u'arctic.library',
                                                  u'unique': True,
-                                                 u'v': 1},
+                                                 u'v': index_version},
                              u'symbol_hashed': {u'background': True,
                                                 u'key': [(u'symbol', u'hashed')],
                                                 u'ns': u'arctic.library',
-                                                u'v': 1}}
+                                                u'v': index_version}}
     snapshots = c.arctic.library.snapshots.index_information()
     assert snapshots == {u'_id_': {u'key': [(u'_id', 1)],
                                                u'ns': u'arctic.library.snapshots',
-                                               u'v': 1},
+                                               u'v': index_version},
                                      u'name_1': {u'background': True,
                                                  u'key': [(u'name', 1)],
                                                  u'ns': u'arctic.library.snapshots',
                                                  u'unique': True,
-                                                 u'v': 1}}
+                                                 u'v': index_version}}
     versions = c.arctic.library.versions.index_information()
     assert versions == {u'_id_': {u'key': [(u'_id', 1)],
                                            u'ns': u'arctic.library.versions',
-                                           u'v': 1},
+                                           u'v': index_version},
                                  u'symbol_1__id_-1': {u'background': True,
                                                       u'key': [(u'symbol', 1), (u'_id', -1)],
                                                       u'ns': u'arctic.library.versions',
-                                                      u'v': 1},
+                                                      u'v': index_version},
                                  u'symbol_1_version_-1': {u'background': True,
                                                           u'key': [(u'symbol', 1), (u'version', -1)],
                                                           u'ns': u'arctic.library.versions',
                                                           u'unique': True,
-                                                          u'v': 1}}
+                                                          u'v': index_version}}
     version_nums = c.arctic.library.version_nums.index_information()
     assert version_nums == {u'_id_': {u'key': [(u'_id', 1)],
                                                u'ns': u'arctic.library.version_nums',
-                                               u'v': 1},
+                                               u'v': index_version},
                                      u'symbol_1': {u'background': True,
                                                    u'key': [(u'symbol', 1)],
                                                    u'ns': u'arctic.library.version_nums',
                                                    u'unique': True,
-                                                   u'v': 1}}
+                                                   u'v': index_version}}
 
 
 def test_delete_library(arctic, library, library_name):


### PR DESCRIPTION
After Mongo 3.4 the index version is 2.
Mongo 3.4 can run with compatibility mode enabled and allow index version 1, but with 3.6 only version 2 is allowed.

https://docs.mongodb.com/manual/release-notes/3.4-compatibility/#compatibility-enabled

In our integration tests, we always expect version 1, which is now breaking.