### PR TITLE
Support for strings in tickstore columns

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -636,6 +636,12 @@ class TickStore(object):
             array = array.astype('<f8')
         elif (array.dtype.kind) in ('U', 'S'):
             array = array.astype(np.unicode_)
+        elif (array.dtype.kind) == 'O':
+            try:
+                array = np.array([s.encode('ascii') for s in array])
+                array = array.astype(np.unicode_)
+            except:
+                raise UnhandledDtypeException("Unsupported dtype '%s' - only int64, float64 and U are supported" % array.dtype)
         else:
             raise UnhandledDtypeException("Unsupported dtype '%s' - only int64, float64 and U are supported" % array.dtype)
         # Everything is little endian in tickstore

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -638,10 +638,10 @@ class TickStore(object):
             array = array.astype(np.unicode_)
         elif (array.dtype.kind) == 'O':
             try:
-                array = np.array([s.encode('ascii') for s in array])
+                array = np.array([s.encode('utf-8') for s in array])
                 array = array.astype(np.unicode_)
             except:
-                raise UnhandledDtypeException("Unsupported dtype '%s' - only int64, float64 and U are supported" % array.dtype)
+                raise UnhandledDtypeException("Casting object column to string failed")
         else:
             raise UnhandledDtypeException("Unsupported dtype '%s' - only int64, float64 and U are supported" % array.dtype)
         # Everything is little endian in tickstore

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -612,3 +612,30 @@ def test_read_with_metadata(tickstore_lib):
     tickstore_lib.write('test', [{'index': dt(2013, 6, 1, 13, 00, tzinfo=mktz('Europe/London')), 'price': 100.50, 'ticker': 'QQQ'}], metadata=metadata)
     m = tickstore_lib.read_metadata('test')
     assert(metadata == m)
+
+
+def test_read_strings(tickstore_lib):
+    df = pd.DataFrame(data={'data': ['A', 'B', 'C']},
+                      index=pd.Index(data=[dt(2016, 1, 1, 00, tzinfo=mktz('UTC')),
+                                           dt(2016, 1, 2, 00, tzinfo=mktz('UTC')),
+                                           dt(2016, 1, 3, 00, tzinfo=mktz('UTC'))], name='date'))
+    tickstore_lib.write('test', df)
+    read_df = tickstore_lib.read('test')
+    assert(all(read_df['data'].values == df['data'].values))
+
+
+def test_objects_fail(tickstore_lib):
+    class Fake(object):
+        def __init__(self, val):
+            self.val = val
+
+        def fake(self):
+            return self.val
+
+    df = pd.DataFrame(data={'data': [Fake(1), Fake(2)]},
+                      index=pd.Index(data=[dt(2016, 1, 1, 00, tzinfo=mktz('UTC')),
+                                           dt(2016, 1, 2, 00, tzinfo=mktz('UTC'))], name='date'))
+
+    with pytest.raises(Exception) as e:
+        tickstore_lib.write('test', df)
+    assert('Unsupported dtype' in str(e))

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -638,4 +638,4 @@ def test_objects_fail(tickstore_lib):
 
     with pytest.raises(Exception) as e:
         tickstore_lib.write('test', df)
-    assert('Unsupported dtype' in str(e))
+    assert('Casting object column to string failed' in str(e))


### PR DESCRIPTION
if the column is an object type, assume its a string. If its not an exception will be raised.