### PR TITLE
Fixing issue where authentication is reset/failed (randomly) 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.56
+  * Bugfix:  #475 change mongo_retry logic to force re-authenticate upon OperationFailure exception
+
 ### 1.55
   * Bugfix:  #439 fix cursor timeouts in chunkstore iterator
   * Bugfix:  #450 fix error in chunkstore delete when chunk range produces empty df

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -48,6 +48,13 @@ def enable_sharding(arctic, library_name, hashed=True, key='symbol'):
     try:
         c.admin.command('enablesharding', dbname)
     except OperationFailure as e:
+        # TODO: very ugly to depend on string value
+        # Maybe better use e.code == 23  (for AlreadyInitialized):
+        # thrown here:
+        #     https://github.com/mongodb/mongo/blob/master/src/mongo/db/s/config/configsvr_shard_collection_command.cpp#L281
+        # defined here:
+        #     https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err#L26
+        #
         if not 'already enabled' in str(e):
             raise
     if not hashed:

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -408,7 +408,8 @@ class ArcticLibraryBinding(object):
         database_name, library = self._parse_db_lib(library)
         self.library = library
         self.database_name = database_name
-        self._auth(self.arctic._conn[self.database_name])
+        self._auth(self._curr_conn[self.database_name])  # authenticate
+        self.get_top_level_collection()  # allow early caching of the library in Arctic (assures _reset is called)
 
     @property
     def _db(self):

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -415,7 +415,7 @@ class ArcticLibraryBinding(object):
     def _db(self):
         with self._lock:
             arctic_conn = self.arctic._conn
-            if arctic_conn is self._curr_conn:
+            if arctic_conn is not self._curr_conn:
                 self._auth(arctic_conn[self.database_name])  # trigger re-authentication if Arctic has been reset
                 self._curr_conn = arctic_conn
         return self.arctic._conn[self.database_name]

--- a/arctic/decorators.py
+++ b/arctic/decorators.py
@@ -1,10 +1,7 @@
-from datetime import datetime
-from functools import wraps
-import os
-import sys
-from time import sleep
 import logging
-
+import sys
+from functools import wraps
+from time import sleep
 from pymongo.errors import AutoReconnect, OperationFailure, DuplicateKeyError, ServerSelectionTimeoutError
 
 from .hooks import log_exception as _log_exception
@@ -12,6 +9,11 @@ from .hooks import log_exception as _log_exception
 logger = logging.getLogger(__name__)
 
 _MAX_RETRIES = 15
+
+
+def _get_store(args):
+    store = args[0] if args and isinstance(args, (list, tuple)) else args
+    return store
 
 
 def _get_host(store):
@@ -32,6 +34,15 @@ _in_retry = False
 _retry_count = 0
 
 
+def _retry_authenticate(store):
+    if store:
+        try:
+            store._arctic_lib.reset_auth()
+        except Exception:
+            # do this transparently, don't add noise to the logs
+            pass
+
+
 def mongo_retry(f):
     """
     Catch-all decorator that handles AutoReconnect and OperationFailure
@@ -44,20 +55,21 @@ def mongo_retry(f):
         global _retry_count, _in_retry
         top_level = not _in_retry
         _in_retry = True
+        store = _get_store(args)
         try:
             while True:
                 try:
                     return f(*args, **kwargs)
                 except (DuplicateKeyError, ServerSelectionTimeoutError) as e:
                     # Re-raise errors that won't go away.
-                    _handle_error(f, e, _retry_count, **_get_host(args))
+                    _handle_error(f, e, _retry_count, store)
                     raise
                 except (OperationFailure, AutoReconnect) as e:
                     _retry_count += 1
-                    _handle_error(f, e, _retry_count, **_get_host(args))
+                    _handle_error(f, e, _retry_count, store)
                 except Exception as e:
                     if log_all_exceptions:
-                        _log_exception(f.__name__, e, _retry_count, **_get_host(args))
+                        _log_exception(f.__name__, e, _retry_count, **_get_host(store))
                     raise
         finally:
             if top_level:
@@ -66,7 +78,7 @@ def mongo_retry(f):
     return f_retry
 
 
-def _handle_error(f, e, retry_count, **kwargs):
+def _handle_error(f, e, retry_count, store):
     if retry_count > _MAX_RETRIES:
         logger.error('Too many retries %s [%s], raising' % (f.__name__, e))
         e.traceback = sys.exc_info()[2]
@@ -74,7 +86,11 @@ def _handle_error(f, e, retry_count, **kwargs):
     log_fn = logger.warning if retry_count > 2 else logger.debug
     log_fn('%s %s [%s], retrying %i' % (type(e), f.__name__, e, retry_count))
     # Log operation failure errors
-    _log_exception(f.__name__, e, retry_count, **kwargs)
-#    if 'unauthorized' in str(e):
-#        raise
-    sleep(0.01 * min((3 ** retry_count), 50))  # backoff...
+    _log_exception(f.__name__, e, retry_count, **_get_host(store))
+    sleep(0.01 * min((3 ** retry_count), 50))
+    if isinstance(e, OperationFailure):  # retry auth after random back-off time
+        # we could have a more specific test here:
+        #   if isinstance(e, OperationFailure) and e.code == 13:
+        # See https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err#L74
+        # Nonetheless, it is no harm to re-authenticate in the background whenever OperationFailure is raised
+        _retry_authenticate(store)

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -115,6 +115,16 @@ class NdarrayStore(object):
                                      ('parent', pymongo.ASCENDING),
                                      ('segment', pymongo.ASCENDING)], unique=True, background=True)
         except OperationFailure as e:
+            # TODO: this is outdated and no longer available after 2.0. See:
+            #       https://github.com/mongodb/mongo/blob/v2.0/s/strategy_single.cpp#L133
+            # Proposal:  use InvalidOptions (code = 72), e.g.:
+            #              if e.code == 72 and "unique" in e and "shard" in e
+            #            Note that InvalidOptions is quite broad and used frequently, not safe without looking for keywords/text.
+            # Thrown:
+            #   - https://github.com/mongodb/mongo/blob/master/src/mongo/db/s/config/configsvr_shard_collection_command.cpp#L151
+            #   - https://github.com/mongodb/mongo/blob/master/src/mongo/db/s/config/configsvr_shard_collection_command.cpp#L347
+            # Defined:
+            #   - https://github.com/mongodb/mongo/blob/master/src/mongo/base/error_codes.err#L74
             if "can't use unique indexes" in str(e):
                 return
             raise

--- a/arctic/tickstore/toplevel.py
+++ b/arctic/tickstore/toplevel.py
@@ -45,6 +45,7 @@ class TopLevelTickStore(object):
         tl._add_libraries()
         tl._ensure_index()
 
+    @mongo_retry
     def _ensure_index(self):
         collection = self._collection
         collection.create_index([('start', pymongo.ASCENDING)], background=True)

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -31,7 +31,7 @@ def test_reset_Arctic(mongo_host, library_name):
     arctic.reset()
     assert c is not arctic._conn
     assert len(c.nodes) == 0
-    assert arctic[library_name]._arctic_lib._curr_conn is c
+    assert arctic[library_name]._arctic_lib._curr_conn is not c
 
 
 def test_re_authenticate_on_arctic_reset(mongo_host, library_name):

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -46,8 +46,8 @@ def test_arctic_auth():
                     store['jblackburn.library']
 
             # Creating the library will have attempted to auth against it
-            ga.assert_called_once_with('cluster', 'arctic', 'arctic_jblackburn')
-            store._conn['arctic_jblackburn'].authenticate.assert_called_once_with('user', 'pass')
+            assert call('cluster', 'arctic', 'arctic_jblackburn') in ga.call_args_list
+            assert call('user', 'pass') in store._conn['arctic_jblackburn'].authenticate.call_args_list
 
 
 def test_arctic_auth_custom_app_name():
@@ -69,7 +69,7 @@ def test_arctic_auth_custom_app_name():
                     store['jblackburn.library']
 
             # Creating the library will have attempted to auth against it
-            assert ga.call_args_list == [call('cluster', sentinel.app_name, 'arctic_jblackburn')]
+            assert call('cluster', sentinel.app_name, 'arctic_jblackburn') in ga.call_args_list
 
 
 def test_arctic_connect_hostname():


### PR DESCRIPTION
We have observed spurious MongoDB OperationFailure exceptions upon common operations like find:

`OperationFailure: not authorized on XXXXXX to execute command { find: "index", filter: { alias: "YYYY" }, limit: 1, singleBatch: true }`

Fixes:
  - Upon creation/initialization of ArcticLibraryBinding we call "get_top_level_collection()" to make sure that Arctic's cache has the library and therefore, if connection is reset, library's "_reset()" is called.
  - When using \@mongo_retry handle OperationFailure exception and try to re-authenticate. This will help successfully issue the mongo command if failure was due to broken/reset authentication.

#475 

