### PR TITLE
Fix slow list versions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ### 1.61
   * Feature: #288 Mapping reads and writes over chunks in chunkstore
   * Bugfix: #508 VersionStore: list_symbols and read now always returns latest version
+  * Bugfix: #512 Improved performance for list_versions
 
 ### 1.60 (2018-2-13)
   * Bugfix: #503 ChunkStore: speedup check for -1 segments

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -247,16 +247,13 @@ class VersionStore(object):
                 raise NoDataFoundException('No snapshot %s in library %s' % (snapshot, self._arctic_lib.get_name()))
 
         versions = []
-        snapshots = None
+        snapshots = {ss.get('_id'): ss.get('name') for ss in self._snapshots.find()}
         for symbol in symbols:
             query['symbol'] = symbol
             seen_symbols = set()
             for version in self._versions.find(query, projection=['symbol', 'version', 'parent', 'metadata.deleted'], sort=[('version', -1)]):
                 if latest_only and version['symbol'] in seen_symbols:
                     continue
-                if snapshots is None:
-                    # populate only once and if is really going to be used
-                    snapshots = {ss.get('_id'): ss.get('name') for ss in self._snapshots.find()}
                 seen_symbols.add(version['symbol'])
                 meta = version.get('metadata')
                 versions.append({'symbol': version['symbol'], 'version': version['version'],

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -260,7 +260,7 @@ class VersionStore(object):
                                  'deleted': meta.get('deleted', False) if meta else False,
                                  # We return offset-aware datetimes in Local Time.
                                  'date': ms_to_datetime(datetime_to_ms(version['_id'].generation_time)),
-                                 'snapshots': [snapshots.get(s) for s in version.get('parent', [])]})
+                                 'snapshots': [snapshots[s] for s in version.get('parent', []) if s in snapshots]})
         return versions
 
     def _find_snapshots(self, parent_ids):


### PR DESCRIPTION
We made unnecessarily multiple calls to _find_snapshots, while we could pre-compute and avoid pushing lots of mongo queries:
https://github.com/manahl/arctic/blob/master/arctic/store/version_store.py#L262

For collections with many symbols, many versions and many snapshots, the improvement is very significant with this fix:

```
Without optimisation:
Total time is: 80.6683588028
Count stats: mean=12.95, std=0.569, min=6, max=13
Time stats: mean=0.083851, std=0.042957, min=0.037374, max=0.484092

With Arctic fix:
Total time is: 11.6488740444
Count stats: mean=12.95, std=0.569, min=6, max=13
Time stats: mean=0.012107, std=0.003715, min=0.008276, max=0.067882
```