### PR TITLE
Fix bug raised in issue #515

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,7 @@
   * Feature: #288 Mapping reads and writes over chunks in chunkstore
   * Bugfix: #508 VersionStore: list_symbols and read now always returns latest version
   * Bugfix: #512 Improved performance for list_versions
+  * Bugfix: #515 VersionStore: _prune_previous_versions now retries the cleanup operation
 
 ### 1.60 (2018-2-13)
   * Bugfix: #503 ChunkStore: speedup check for -1 segments

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -764,7 +764,7 @@ class VersionStore(object):
         # Delete the version documents
         mongo_retry(self._versions.delete_many)({'_id': {'$in': version_ids}})
         # Cleanup any chunks
-        cleanup(self._arctic_lib, symbol, version_ids)
+        mongo_retry(cleanup)(self._arctic_lib, symbol, version_ids)
 
     @mongo_retry
     def _delete_version(self, symbol, version_num, do_cleanup=True):


### PR DESCRIPTION
VersionStore: _prune_previous_versions now retries the cleanup operation, preventing an exception to be raised during step downs.