### PR TITLE
Fix for issue #517

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 1.62
+  * Bugfix: #517 VersionStore: append does not duplicate data in certain corner cases
+
 ### 1.61 (2018-3-2)
   * Feature: #288 Mapping reads and writes over chunks in chunkstore
   * Bugfix: #508 VersionStore: list_symbols and read now always returns latest version

--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -13,6 +13,7 @@ import time
 import pytest
 import numpy as np
 
+import arctic
 from arctic.exceptions import NoDataFoundException, DuplicateSnapshotException
 from arctic.date import DateRange
 from arctic.store import _version_store_utils
@@ -1306,3 +1307,68 @@ def test_prune_previous_versions_retries_find_calls(library):
         library._prune_previous_versions(symbol, keep_mins=0)
 
     assert library._versions.count({'symbol': symbol}) == 1
+
+
+def test_append_does_not_duplicate_data_when_prune_fails(library):
+    side_effect = [OperationFailure(0), arctic.store.version_store.VersionStore._prune_previous_versions]
+    new_data = read_str_as_pandas("""times | near
+    2013-01-01 17:06:11.040 |  7.0
+    2013-01-02 17:06:11.040 |  8.2
+    2013-01-03 17:06:11.040 |  3.5
+    2013-01-04 17:06:11.040 |  0.7""")
+    library.write(symbol, ts1)
+
+    with patch.object(arctic.store.version_store.VersionStore, "_prune_previous_versions", autospec=True, side_effect=side_effect):
+        library.append(symbol, new_data)
+
+    data = library.read(symbol).data
+    assert len(set(data.index)) == len(data.index)
+
+
+def test_append_does_not_duplicate_data_when_publish_fails(library):
+    side_effect = [OperationFailure(0), arctic.store.version_store.VersionStore._publish_change]
+    new_data = read_str_as_pandas("""times | near
+    2013-01-01 17:06:11.040 |  7.0
+    2013-01-02 17:06:11.040 |  8.2
+    2013-01-03 17:06:11.040 |  3.5
+    2013-01-04 17:06:11.040 |  0.7""")
+    library.write(symbol, ts1)
+
+    with patch.object(arctic.store.version_store.VersionStore, "_publish_change", autospec=True, side_effect=side_effect):
+        library.append(symbol, new_data)
+
+    data = library.read(symbol).data
+    assert len(set(data.index)) == len(data.index)
+
+
+def test_write_does_not_succeed_with_a_prune_error(library):
+    # More than max retries OperationFailure would be more realistic, but ValueError is used for simplicity
+    side_effect = [ValueError, arctic.store.version_store.VersionStore._prune_previous_versions]
+    library.write(symbol, ts1)
+
+    with patch.object(arctic.store.version_store.VersionStore, "_prune_previous_versions", autospec=True, side_effect=side_effect):
+        with pytest.raises(ValueError):
+            library.write(symbol, ts1)
+
+    assert len(library.list_versions(symbol)) == 1
+
+
+def test_write_does_not_succeed_with_a_publish_error(library):
+    # More than max retries OperationFailure would be more realistic, but ValueError is used for simplicity
+    side_effect = [ValueError, arctic.store.version_store.VersionStore._publish_change]
+
+    with patch.object(arctic.store.version_store.VersionStore, "_publish_change", autospec=True, side_effect=side_effect):
+        with pytest.raises(ValueError):
+            library.append(symbol, ts1)
+
+    assert not library.list_versions(symbol)
+
+
+def test_prune_keeps_version(library):
+    library.write(symbol, ts1)
+    library.write(symbol, ts1)
+    old_version = [v["_id"] for v in library._versions.find({"symbol": symbol}, sort=[("_id", 1)])][0]
+
+    library._prune_previous_versions(symbol, keep_mins=0, keep_version=old_version)
+
+    assert len(library.list_versions(symbol)) == 2

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -490,8 +490,8 @@ def test_write_insert_version_duplicatekey():
     assert vs._version_nums.find_one_and_update.call_count == 2
     assert vs._versions.find_one.call_count == 2
     assert write_handler.write.call_count == 2
+    assert vs._publish_change.call_count == 2
     assert vs._versions.insert_one.call_count == 2
-    assert vs._publish_change.call_count == 1
 
 
 def test_write_insert_version_operror():
@@ -555,7 +555,7 @@ def test_append_insert_version_duplicatekey():
     assert vs._versions.find_one.call_count == 2
     assert read_handler.append.call_count == 2
     assert vs._versions.insert_one.call_count == 2
-    assert vs._publish_change.call_count == 1
+    assert vs._publish_change.call_count == 2
 
 def test_append_insert_version_operror():
     read_handler = Mock(append=Mock(__name__=""))

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -195,7 +195,7 @@ def test_prune_previous_versions_0_timeout():
     self._versions.with_options.return_value.find.return_value = []
     with patch('arctic.store.version_store.dt') as dt:
         dt.utcnow.return_value = datetime.datetime(2013, 10, 1)
-        VersionStore._prune_previous_versions(self, sentinel.symbol, keep_mins=0)
+        VersionStore._find_prunable_version_ids(self, sentinel.symbol, keep_mins=0)
     assert self._versions.with_options.call_args_list == [call(read_preference=ReadPreference.PRIMARY)]
     assert self._versions.with_options.return_value.find.call_args_list == [
                                                   call({'$or': [{'parent': {'$exists': False}},
@@ -204,7 +204,7 @@ def test_prune_previous_versions_0_timeout():
                                                         '_id': {'$lt': bson.ObjectId('524a10810000000000000000')}},
                                                        sort=[('version', -1)],
                                                        skip=1,
-                                                       projection=['_id', 'type'])]
+                                                       projection=['_id'])]
 
 
 def test_read_handles_operation_failure():


### PR DESCRIPTION
The commit 4015af8 fixes the first part of the problem: calls to find are now retried instead of raising OperationFailure. This is enough to solve all cases where a duplicated append happens, as mongo_retries are global to the append/write call.

However, the commit fd3c999 was added to make the code safer to potential issues that may cause an exception be raised after a version is created.