### PR TITLE
issue 521 - updated setup.py for clang-6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,8 @@ Arctic currently works with:
 
 
 Operating Systems:
-
  * Linux
  * macOS
-
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 
 ## Requirements
 
-##### Arctic currently works with:
+Arctic currently works with:
 
  * Python 2.7, 3.4, 3.5, 3.6
  * pymongo >= 3.0
@@ -116,13 +116,11 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
  * MongoDB >= 2.4.x
 
 
-##### Operating Systems:
+Operating Systems:
 
  * Linux
  * macOS
 
-##### Installation on macOS
-To install on macOS, either of the gcc or llvm compilers must be installed. Apple's llvm compiler included with Xcode or Command Line Tools will not work.  The easiest way to install one of these compilers is to use [Homebrew](https://brew.sh).  Once Homebrew is installed, issue the command `brew install gcc` or `brew install llvm`.  If you choose to install llvm, you also have to `brew install libomp`.  These can be uninstalled later by issuing a `brew uninstall ...` command.
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 
 ## Requirements
 
-Arctic currently works with:
+##### Arctic currently works with:
 
  * Python 2.7, 3.4, 3.5, 3.6
  * pymongo >= 3.0
@@ -116,9 +116,13 @@ Arctic currently works with:
  * MongoDB >= 2.4.x
 
 
-Operating Systems:
+##### Operating Systems:
+
  * Linux
  * macOS
+
+##### Installation on macOS
+To install on macOS, either of the gcc or llvm compilers must be installed. Apple's llvm compiler included with Xcode or Command Line Tools will not work.  The easiest way to install one of these compilers is to use [Homebrew](https://brew.sh).  Once Homebrew is installed, issue the command `brew install gcc` or `brew install llvm`.  If you choose to install llvm, you also have to `brew install libomp`.  These can be uninstalled later by issuing a `brew uninstall ...` command.
 
 ## Acknowledgements
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ import os
 import platform
 
 
-link_args = ['-fopenmp']
+link_args = ['']
 
 if platform.system().lower() == 'darwin':
     # clang on macOS does not work with OpenMP
@@ -39,15 +39,15 @@ if platform.system().lower() == 'darwin':
         if os.path.isfile(compiler):
             cc = compiler
     if cc is None:
-        raise ValueError("You must install clang-5.0 or gcc/g++. You can install with homebrew: brew install gcc or brew install llvm")
+        raise ValueError("You must install clang-6.0 or gcc/g++. You can install with homebrew: brew install gcc or brew install llvm")
     os.environ["CC"] = cc if 'clang' in cc else cc.replace("g++", "gcc")
     os.environ["CXX"] = cc
     # not all OSX/clang compiler flags supported by GCC. For some reason
     # these sometimes are generated and used. Cython will still add more flags.
     os.environ["CFLAGS"] = "-fno-common -fno-strict-aliasing -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -g -fwrapv -Os"
 
-    if 'clang' in cc:
-        link_args = ['-fopenmp=libiomp5']
+    if 'g++' in cc:
+        link_args = ['-fopenmp']
 
 # Convert Markdown to RST for PyPI
 # http://stackoverflow.com/a/26737672

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ import platform
 link_args = ['']
 
 if platform.system().lower() == 'darwin':
-    # clang on macOS does not work with OpenMP
+ 
     ccs = ["/usr/local/bin/g++-5",
            "/usr/local/bin/g++-6",
            "/usr/local/bin/g++-7",

--- a/setup.py
+++ b/setup.py
@@ -26,10 +26,10 @@ import os
 import platform
 
 
-link_args = ['']
+link_args = ['-fopenmp']
 
 if platform.system().lower() == 'darwin':
- 
+    # clang on macOS does not work with OpenMP
     ccs = ["/usr/local/bin/g++-5",
            "/usr/local/bin/g++-6",
            "/usr/local/bin/g++-7",
@@ -40,14 +40,16 @@ if platform.system().lower() == 'darwin':
             cc = compiler
     if cc is None:
         raise ValueError("You must install clang-6.0 or gcc/g++. You can install with homebrew: brew install gcc or brew install llvm")
+    if 'clang' in cc and os.path.isdir("/usr/local/opt/libomp")==False:
+        raise ValueError("You must also install libomp.  You can install with homebrew: brew install libomp")
     os.environ["CC"] = cc if 'clang' in cc else cc.replace("g++", "gcc")
     os.environ["CXX"] = cc
     # not all OSX/clang compiler flags supported by GCC. For some reason
     # these sometimes are generated and used. Cython will still add more flags.
     os.environ["CFLAGS"] = "-fno-common -fno-strict-aliasing -DENABLE_DTRACE -DMACOSX -DNDEBUG -Wall -g -fwrapv -Os"
 
-    if 'g++' in cc:
-        link_args = ['-fopenmp']
+    if 'clang' in cc:
+        link_args = ['-fopenmp=libomp']
 
 # Convert Markdown to RST for PyPI
 # http://stackoverflow.com/a/26737672


### PR DESCRIPTION
clang-6.0 includes openmp support by default, so the linker flag is no longer required so long as the compiler flag was included.  Therefore in [setup.py](https://github.com/manahl/arctic/blob/master/setup.py) make the default `link_args` empty at line 29, and if gcc is the installed compiler add the `link_arg` `-fopenmp` at line 50.  Also updated the ValueError to reference clang-6.0 (now default install when executing `brew install llvm`).

As I reviewed this before submission, I see that I could have deleted the comment at line 32 also as this is not true. _(fixed in subsequent commit)_