### PR TITLE
Check dtype before concatenating on write (issue #534)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### 1.64
+  * Bugfix: #534 VersionStore: overwriting a symbol with different dtype (but same data format) does not
+                 raise exceptions anymore
   * Bugfix: #531 arctic_prune_versions: clean broken snapshot references before pruning
   * Feature: #490 add support to numpy 1.14
 

--- a/arctic/fixtures/arctic.py
+++ b/arctic/fixtures/arctic.py
@@ -1,6 +1,8 @@
+import base64
 import getpass
 import logging
 
+import bson
 import pytest as pytest
 
 from .. import arctic as m
@@ -32,6 +34,250 @@ def arctic(mongo_server):
 def arctic_secondary(mongo_server, arctic):
     arctic = m.Arctic(mongo_host=mongo_server.api, allow_secondary=True)
     return arctic
+
+@pytest.fixture(scope="function")
+def multicolumn_store_with_uncompressed_write(mongo_server):
+    """
+    The database state created by this fixture is equivalent to the following operations using arctic 1.40
+    or previous:
+
+        arctic.initialize_library('arctic_test.TEST', m.VERSION_STORE, segment='month')
+        library = arctic.get_library('arctic_test.TEST')
+        df = pd.DataFrame([[1,2], [3,4]], index=['x','y'], columns=[['a','w'], ['a','v']])
+        library.write('pandas', df)
+
+    different from newer versions, the last write creates a uncompressed chunk.
+    """
+    mongo_server.api.drop_database('arctic_test')
+
+    library_name = 'arctic_test.TEST'
+    arctic = m.Arctic(mongo_host=mongo_server.api)
+    arctic.initialize_library(library_name, m.VERSION_STORE, segment='month')
+
+    db = mongo_server.api.arctic_test
+    db.TEST.insert_many([
+        {
+            'parent': [bson.ObjectId('5ad0dc065c911d1188b512d8')],
+            'data': bson.Binary(b'\x11\x00\x00\x002x\x01\x00\x01\x00\x80\x02\x00\x00\x00\x00\x00\x00\x00', 0),
+            'symbol': 'pandas',
+            'sha': bson.Binary(b'\xaa\\`\x0e\xc2D-\xc1_\xf7\xfd\x12\xfa\xd2\x17\x05`\x00\x98\xe2', 0),
+            'compressed': True,
+            '_id': bson.ObjectId('5ad0dc067934ecad404070be'),
+            'segment': 0
+        },
+        {
+            'parent': [bson.ObjectId('5ad0dc065c911d1188b512d8')],
+            'data': bson.Binary(b'y\x03\x00\x00\x00\x00\x00\x00\x00\x04\x00\x00\x00\x00\x00\x00\x00', 0),
+            'symbol': 'pandas',
+            'sha': bson.Binary(b'\xfe=WQ\xb5\xfdL\xb7\xcavd\x85o\x04]\x04\xdb\xa8]3', 0),
+            'compressed': False,
+            '_id': bson.ObjectId('5ad0dc077934ecad404070bf'),
+            'segment': 1
+        }
+    ])
+    db.TEST.ARCTIC.update_one({"_id": "ARCTIC_META"}, {"$set": {"_id": "ARCTIC_META", "TYPE": "VersionStore", "QUOTA": 10737418240}})
+    db.TEST.changes.insert_many([
+        {
+            'append_count': 0,
+            'dtype_metadata': {
+                'index': ['index'],
+                'columns': ["('a', 'a')", "('w', 'v')"]
+            },
+            'segment_count': 1,
+            'dtype': '[(\'index\', \'S1\'), ("(\'a\', \'a\')", \'<i8\'), ("(\'w\', \'v\')", \'<i8\')]',
+            'symbol': 'pandas',
+            'up_to': 1,
+            'metadata': None,
+            'sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            'shape': [-1],
+            'version': 1,
+            'base_sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            '_id': bson.ObjectId('5ad0dc065c911d1188b512d8'),
+            'type': 'pandasdf',
+            'append_size': 0
+        },
+        {
+            'append_count': 1,
+            'dtype_metadata': {
+                'index': ['index'],
+                'columns': ["('a', 'a')", "('w', 'v')"]
+            },
+            'segment_count': 2,
+            'sha': bson.Binary(b'1\x83[ZO\xec\x080D\x80f\xe4@\xe4\xd3\x94yG\xe2\x08', 0),
+            'dtype': '[(\'index\', \'S1\'), ("(\'a\', \'a\')", \'<i8\'), ("(\'w\', \'v\')", \'<i8\')]',
+            'symbol': 'pandas',
+            'up_to': 2,
+            'metadata': None,
+            'base_version_id': bson.ObjectId('5ad0dc065c911d1188b512d8'),
+            'shape': [-1],
+            'version': 2,
+            'base_sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            '_id': bson.ObjectId('5ad0dc075c911d1188b512d9'),
+            'type': 'pandasdf',
+            'append_size': 17
+        }
+    ])
+    db.TEST.version_nums.insert_one({'symbol': 'pandas', '_id': bson.ObjectId('5ad0dc067934ecad404070bd'), 'version': 2})
+    db.TEST.versions.insert_many([
+        {
+            'append_count': 0,
+            'dtype_metadata': {
+                'index': ['index'],
+                'columns': ["('a', 'a')", "('w', 'v')"]
+            },
+            'segment_count': 1,
+            'dtype': '[(\'index\', \'S1\'), ("(\'a\', \'a\')", \'<i8\'), ("(\'w\', \'v\')", \'<i8\')]',
+            'symbol': 'pandas',
+            'up_to': 1,
+            'metadata': None,
+            'sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            'shape': [-1],
+            'version': 1,
+            'base_sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            '_id': bson.ObjectId('5ad0dc065c911d1188b512d8'),
+            'type': 'pandasdf',
+            'append_size': 0
+        },
+        {
+            'append_count': 1,
+            'dtype_metadata': {
+                'index': ['index'],
+                'columns': ["('a', 'a')", "('w', 'v')"]
+            },
+            'segment_count': 2,
+            'sha': bson.Binary(b'1\x83[ZO\xec\x080D\x80f\xe4@\xe4\xd3\x94yG\xe2\x08', 0),
+            'dtype': '[(\'index\', \'S1\'), ("(\'a\', \'a\')", \'<i8\'), ("(\'w\', \'v\')", \'<i8\')]',
+            'symbol': 'pandas',
+            'up_to': 2,
+            'metadata': None,
+            'base_version_id': bson.ObjectId('5ad0dc065c911d1188b512d8'),
+            'shape': [-1],
+            'version': 2,
+            'base_sha': bson.Binary(b'\xf2\x15h\x9d\x925\x95\xa5\x0e\x95J\xc4x\xfc\xfc\xd5\x80\xe0\x1d\xef', 0),
+            '_id': bson.ObjectId('5ad0dc075c911d1188b512d9'),
+            'type': 'pandasdf',
+            'append_size': 17
+        }
+    ])
+
+    return {'symbol': 'pandas', 'store': arctic.get_library('arctic_test.TEST')}
+
+
+@pytest.fixture(scope="function")
+def ndarray_store_with_uncompressed_write(mongo_server):
+    """
+    The database state created by this fixture is equivalent to the following operations using arctic 1.40
+    or previous:
+
+        arctic.initialize_library('arctic_test.TEST', m.VERSION_STORE, segment='month')
+        library = arctic.get_library('arctic_test.TEST')
+        arr = np.arange(2).astype([('abc', 'int64')])
+        library.write('MYARR', arr[:1])
+        library.write('MYARR', arr)
+
+    different from newer versions, the last write creates a uncompressed chunk.
+    """
+    mongo_server.api.drop_database('arctic_test')
+
+    library_name = 'arctic_test.TEST'
+    arctic = m.Arctic(mongo_host=mongo_server.api)
+    arctic.initialize_library(library_name, m.VERSION_STORE, segment='month')
+
+    db = mongo_server.api.arctic_test
+    db.TEST.insert_many([
+        {
+            "_id": bson.ObjectId("5ad0742ca0949de6727cf994"),
+            "segment": 0,
+            "sha": bson.Binary(base64.b64decode("Fk+quqPVSDfaajYJkOAvnDyXtGQ="), 0),
+            "symbol": "MYARR",
+            "data": bson.Binary(base64.b64decode("CAAAAIAAAAAAAAAAAA=="), 0),
+            "compressed": True,
+            "parent": [bson.ObjectId("5ad0742c5c911d4d80ee2ea3")]
+        },
+        {
+            "_id": bson.ObjectId("5ad0742ca0949de6727cf995"),
+            "sha": bson.Binary(base64.b64decode("eqpp8VOJBttTz0j5H+QGtOQ+r44="), 0),
+            "symbol": "MYARR",
+            "segment": 1,
+            "data": bson.Binary(base64.b64decode("AQAAAAAAAAA="), 0),
+            "compressed": False,
+            "parent": [bson.ObjectId("5ad0742c5c911d4d80ee2ea3")]
+        }
+    ])
+    db.TEST.ARCTIC.update_one({"_id": "ARCTIC_META"}, {"$set": {"_id": "ARCTIC_META", "TYPE": "VersionStore", "QUOTA": 10737418240}})
+    db.TEST.changes.insert_many([
+        {
+            "_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea3"),
+            "append_count": 0,
+            "dtype_metadata": {},
+            "segment_count": 1,
+            "dtype": "[('abc', '<i8')]",
+            "symbol": "MYARR",
+            "up_to": 1,
+            "append_size": 0,
+            "sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "shape": [-1],
+            "version": 1,
+            "base_sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "type": "ndarray",
+            "metadata": None
+        },
+        {
+            "_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea4"),
+            "append_count": 1,
+            "dtype_metadata": {},
+            "segment_count": 2,
+            "base_version_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea3"),
+            "dtype": "[('abc', '<i8')]",
+            "symbol": "MYARR",
+            "up_to": 2,
+            "append_size": 8,
+            "sha": bson.Binary(base64.b64decode("Ax7oBxVFw1/9wKog2gfOLjbOVD8="), 0),
+            "shape": [-1],
+            "version": 2,
+            "base_sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "type": "ndarray",
+            "metadata": None
+        }
+    ])
+    db.TEST.versions_nums.insert_one({"_id": bson.ObjectId("5ad0742ca0949de6727cf993"), "symbol": "MYARR", "version": 2})
+    db.TEST.versions.insert_many([
+        {
+            "_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea3"),
+            "append_count": 0,
+            "dtype_metadata": {},
+            "segment_count": 1,
+            "dtype": "[('abc', '<i8')]",
+            "symbol": "MYARR",
+            "up_to": 1,
+            "append_size": 0,
+            "sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "shape": [-1],
+            "version": 1,
+            "base_sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "type": "ndarray",
+            "metadata": None
+        },
+        {
+            "_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea4"),
+            "append_count": 1,
+            "dtype_metadata": {},
+            "segment_count": 2,
+            "base_version_id": bson.ObjectId("5ad0742c5c911d4d80ee2ea3"),
+            "dtype": "[('abc', '<i8')]",
+            "symbol": "MYARR",
+            "up_to": 2,
+            "append_size": 8,
+            "sha": bson.Binary(base64.b64decode("Ax7oBxVFw1/9wKog2gfOLjbOVD8="), 0),
+            "shape": [-1],
+            "version": 2,
+            "base_sha": bson.Binary(base64.b64decode("Bf5AV1MWbxJVWefJrFWGVPEHx+k="), 0),
+            "type": "ndarray",
+            "metadata": None
+        }
+    ])
+
+    return {'symbol': 'MYARR', 'store': arctic.get_library('arctic_test.TEST')}
 
 
 @pytest.fixture(scope="function")

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -456,6 +456,7 @@ class NdarrayStore(object):
 
         if previous_version:
             if 'sha' in previous_version \
+                    and previous_version['dtype'] == version['dtype'] \
                     and self.checksum(item[:previous_version['up_to']]) == previous_version['sha']:
                 # The first n rows are identical to the previous version, so just append.
                 # Do a 'dirty' append (i.e. concat & start from a new base version) for safety

--- a/tests/integration/store/test_ndarray_store.py
+++ b/tests/integration/store/test_ndarray_store.py
@@ -15,6 +15,18 @@ from tests.integration.store.test_version_store import _query
 register_versioned_storage(NdarrayStore)
 
 
+def test_write_new_column_name_to_arctic_1_40_data(ndarray_store_with_uncompressed_write):
+    store = ndarray_store_with_uncompressed_write['store']
+    symbol = ndarray_store_with_uncompressed_write['symbol']
+
+    arr = store.read(symbol).data
+    new_arr = np.array(list(arr) + [(2,)], dtype=[('fgh', '<i8')])
+
+    store.write(symbol, new_arr)
+
+    assert np.all(store.read(symbol).data == new_arr)
+
+
 def test_save_read_simple_ndarray(library):
     ndarr = np.ones(1000)
     library.write('MYARR', ndarr)

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -22,6 +22,16 @@ from tests.util import read_str_as_pandas
 register_versioned_storage(PandasDataFrameStore)
 
 
+def test_write_multi_column_to_arctic_1_40_data(multicolumn_store_with_uncompressed_write):
+    store = multicolumn_store_with_uncompressed_write['store']
+    symbol = multicolumn_store_with_uncompressed_write['symbol']
+
+    df = pd.DataFrame([[1, 2], [3, 4], [5, 6]], index=['x', 'y', 'z'], columns=[[u'a', 'w'], ['a', 'v']])
+    store.write(symbol, df)
+
+    assert np.all(store.read(symbol).data == df)
+
+
 def test_save_read_pandas_series(library):
     s = Series(data=[1, 2, 3], index=[4, 5, 6])
     library.write('pandas', s)


### PR DESCRIPTION
This line will https://github.com/manahl/arctic/blob/v1.63.0/arctic/store/_ndarray_store.py#L389 raise a `TypeError: invalid type promotion` if there is uncompressed data with a different dtype from the new data being written.

That line can be reached with a different dtype if the data is actually the same, except for a column name change. Moreover, uncompressed data can have a 'sha' value in versions prior to 1.41. So this is an issue mainly when migrating from old version.

This fixes issue https://github.com/manahl/arctic/issues/534