### PR TITLE
Add advanced query for list_symbols() similar to VersionStore

### DIFF
--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -9,9 +9,15 @@ except ImportError:
     from pandas.lib import infer_dtype
 
 try:
-    from pandas._libs.lib import max_len_string_array
+    # pandas >= 0.23.0
+    from pandas._libs.writers import max_len_string_array
 except ImportError:
-    from pandas.lib import max_len_string_array
+    try:
+        # pandas [0.20.0, 0.22.x]
+        from pandas._libs.lib import max_len_string_array
+    except ImportError:
+        # pandas <=  0.19.x
+        from pandas.lib import max_len_string_array
 
 from bson import Binary, SON
 

--- a/arctic/store/bson_store.py
+++ b/arctic/store/bson_store.py
@@ -164,6 +164,13 @@ class BSONStore(object):
         return self._collection.count(filter, **kwargs)
 
     @mongo_retry
+    def aggregate(self, pipeline, **kwargs):
+        """
+        See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.aggregate
+        """
+        return self._collection.aggregate(pipeline, **kwargs)
+
+    @mongo_retry
     def distinct(self, key, **kwargs):
         """
         See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.distinct

--- a/tests/integration/test_compress_integration.py
+++ b/tests/integration/test_compress_integration.py
@@ -3,14 +3,26 @@ import random
 try:
     from lz4 import compressHC as lz4_compress, decompress as lz4_decompress
 except ImportError as e:
-    from lz4.frame import compress as lz4_compress, decompress as lz4_decompress
+    from lz4.block import compress as lz4_compress, decompress as lz4_decompress
 
 import string
 import pytest
 import six
 from datetime import datetime as dt
-
 import arctic._compress as c
+
+
+@pytest.mark.parametrize("compress,decompress", [
+    (c.compress, lz4_decompress),
+    (c.compressHC, lz4_decompress),
+    (lz4_compress, c.decompress)
+], ids=('arctic/lz4',
+        'arcticHC/lz4',
+        'lz4/arctic'))
+def test_roundtrip(compress, decompress):
+    _str = b"hello world"
+    cstr = compress(_str)
+    assert _str == decompress(cstr)
 
 
 @pytest.mark.parametrize("n, length", [(300, 5e4),  # micro TS

--- a/tests/unit/store/test_metadata_store.py
+++ b/tests/unit/store/test_metadata_store.py
@@ -27,8 +27,8 @@ def test_list_symbols_regex():
 
     expected_pipeline = [
         {'$match': {'symbol': {'$regex': 'test.*'}}},
-        {'$sort': {'start_time': -1}},
-        {'$group': {'_id': '$symbol'}},
+        {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
 
@@ -42,8 +42,8 @@ def test_list_symbols_as_of():
 
     expected_pipeline = [
         {'$match': {'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
-        {'$sort': {'start_time': -1}},
-        {'$group': {'_id': '$symbol'}},
+        {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
 
@@ -58,8 +58,8 @@ def test_list_symbols_as_of_regex():
     expected_pipeline = [
         {'$match': {'symbol': {'$regex': 'test.*'},
                     'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
-        {'$sort': {'start_time': -1}},
-        {'$group': {'_id': '$symbol'}},
+        {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
 
@@ -74,9 +74,9 @@ def test_list_symbols_metadata_query():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
+        {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$match': {'metadata.foo': 'bar'}},
-        {'$sort': {'start_time': -1}},
-        {'$group': {'_id': '$symbol'}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
 
@@ -89,11 +89,11 @@ def test_list_symbols_all_options():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
-        {'$match': {'metadata.foo': 'bar',
-                    'symbol': {'$regex': 'test.*'},
+        {'$match': {'symbol': {'$regex': 'test.*'},
                     'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
-        {'$sort': {'start_time': -1}},
-        {'$group': {'_id': '$symbol'}},
+        {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
+        {'$match': {'metadata.foo': 'bar'}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
 

--- a/tests/unit/store/test_metadata_store.py
+++ b/tests/unit/store/test_metadata_store.py
@@ -26,8 +26,8 @@ def test_list_symbols_regex():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
-        {'$match': {'symbol': {'$regex': 'test.*'}}},
         {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$match': {'symbol': {'$regex': 'test.*'}}},
         {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
@@ -41,8 +41,9 @@ def test_list_symbols_as_of():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
-        {'$match': {'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
         {'$sort': {'symbol': 1, 'start_time': -1}},
+        {'$match': {'symbol': {'$regex': '^'},
+                    'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
         {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
@@ -56,9 +57,9 @@ def test_list_symbols_as_of_regex():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
+        {'$sort': {'symbol': 1, 'start_time': -1}},
         {'$match': {'symbol': {'$regex': 'test.*'},
                     'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
-        {'$sort': {'symbol': 1, 'start_time': -1}},
         {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}
     ]
@@ -89,9 +90,9 @@ def test_list_symbols_all_options():
     ms.aggregate.return_value = []
 
     expected_pipeline = [
+        {'$sort': {'symbol': 1, 'start_time': -1}},
         {'$match': {'symbol': {'$regex': 'test.*'},
                     'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
-        {'$sort': {'symbol': 1, 'start_time': -1}},
         {'$group': {'_id': '$symbol', 'metadata': {'$first': '$metadata'}}},
         {'$match': {'metadata.foo': 'bar'}},
         {'$project': {'_id': 0, 'symbol':  '$_id'}}

--- a/tests/unit/store/test_metadata_store.py
+++ b/tests/unit/store/test_metadata_store.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 from arctic.store.metadata_store import MetadataStore
 from mock import create_autospec, call
 
@@ -5,4 +7,98 @@ from mock import create_autospec, call
 def test_ensure_index():
     ms = create_autospec(MetadataStore)
     MetadataStore._ensure_index(ms)
-    assert ms.create_index.call_args_list == [call([('symbol', 1), ('start_time', -1)], unique=True, background=True)]
+    assert ms.create_index.call_args_list == [call([('symbol', 1),
+                                                    ('start_time', -1)],
+                                                   unique=True,
+                                                   background=True)]
+
+
+def test_list_symbols_simple():
+    ms = create_autospec(MetadataStore)
+    ms.distinct.return_value = []
+
+    MetadataStore.list_symbols(ms)
+    ms.distinct.assert_called_once_with('symbol')
+
+
+def test_list_symbols_regex():
+    ms = create_autospec(MetadataStore)
+    ms.aggregate.return_value = []
+
+    expected_pipeline = [
+        {'$match': {'symbol': {'$regex': 'test.*'}}},
+        {'$sort': {'start_time': -1}},
+        {'$group': {'_id': '$symbol'}},
+        {'$project': {'_id': 0, 'symbol':  '$_id'}}
+    ]
+
+    MetadataStore.list_symbols(ms, regex='test.*')
+    ms.aggregate.assert_called_once_with(expected_pipeline)
+
+
+def test_list_symbols_as_of():
+    ms = create_autospec(MetadataStore)
+    ms.aggregate.return_value = []
+
+    expected_pipeline = [
+        {'$match': {'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
+        {'$sort': {'start_time': -1}},
+        {'$group': {'_id': '$symbol'}},
+        {'$project': {'_id': 0, 'symbol':  '$_id'}}
+    ]
+
+    MetadataStore.list_symbols(ms, as_of=dt.datetime(2018, 5, 11))
+    ms.aggregate.assert_called_once_with(expected_pipeline)
+
+
+def test_list_symbols_as_of_regex():
+    ms = create_autospec(MetadataStore)
+    ms.aggregate.return_value = []
+
+    expected_pipeline = [
+        {'$match': {'symbol': {'$regex': 'test.*'},
+                    'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
+        {'$sort': {'start_time': -1}},
+        {'$group': {'_id': '$symbol'}},
+        {'$project': {'_id': 0, 'symbol':  '$_id'}}
+    ]
+
+    MetadataStore.list_symbols(ms,
+                               regex='test.*',
+                               as_of=dt.datetime(2018, 5, 11))
+    ms.aggregate.assert_called_once_with(expected_pipeline)
+
+
+def test_list_symbols_metadata_query():
+    ms = create_autospec(MetadataStore)
+    ms.aggregate.return_value = []
+
+    expected_pipeline = [
+        {'$match': {'metadata.foo': 'bar'}},
+        {'$sort': {'start_time': -1}},
+        {'$group': {'_id': '$symbol'}},
+        {'$project': {'_id': 0, 'symbol':  '$_id'}}
+    ]
+
+    MetadataStore.list_symbols(ms, foo='bar')
+    ms.aggregate.assert_called_once_with(expected_pipeline)
+
+
+def test_list_symbols_all_options():
+    ms = create_autospec(MetadataStore)
+    ms.aggregate.return_value = []
+
+    expected_pipeline = [
+        {'$match': {'metadata.foo': 'bar',
+                    'symbol': {'$regex': 'test.*'},
+                    'start_time': {'$lte': dt.datetime(2018, 5, 11)}}},
+        {'$sort': {'start_time': -1}},
+        {'$group': {'_id': '$symbol'}},
+        {'$project': {'_id': 0, 'symbol':  '$_id'}}
+    ]
+
+    MetadataStore.list_symbols(ms,
+                               regex='test.*',
+                               as_of=dt.datetime(2018, 5, 11),
+                               foo='bar')
+    ms.aggregate.assert_called_once_with(expected_pipeline)

--- a/tests/unit/test_compress.py
+++ b/tests/unit/test_compress.py
@@ -1,4 +1,3 @@
-import lz4
 import pytest
 import random
 import string
@@ -6,9 +5,12 @@ import string
 import arctic._compress as c
 
 
-def test_roundtrip():
+@pytest.mark.parametrize("compress",
+                         [c.compress, c.compressHC],
+                         ids=('arctic', 'arcticHC'))
+def test_roundtrip(compress):
     _str = b"hello world"
-    cstr = c.compress(_str)
+    cstr = compress(_str)
     assert _str == c.decompress(cstr)
 
 
@@ -18,35 +20,6 @@ def test_roundtrip_multi(n):
     cstr = c.compress(_str)
     assert _str == c.decompress(cstr)
 
-
-def test_roundtripHC():
-    _str = b"hello world"
-    cstr = c.compressHC(_str)
-    assert _str == c.decompress(cstr)
-
-
-def test_roundtripLZ4():
-    _str = b"hello world"
-    cstr = lz4.compress(_str)
-    assert _str == c.decompress(cstr)
-
-
-def test_roundtripLZ4Back():
-    _str = b"hello world"
-    cstr = c.compress(_str)
-    assert _str == lz4.decompress(cstr)
-
-
-def test_roundtripLZ4HC():
-    _str = b"hello world"
-    cstr = lz4.compressHC(_str)
-    assert _str == c.decompress(cstr)
-
-
-def test_roundtripLZ4HCBack():
-    _str = b"hello world"
-    cstr = c.compressHC(_str)
-    assert _str == lz4.decompress(cstr)
 
 
 @pytest.mark.parametrize("n, length", [(1, 10), (100, 10), (1000, 10)])


### PR DESCRIPTION
Adding missing features:
- regex symbol lookup
- as_of support - show symbols valid starting with the provided date
- metadata field exact match queries