### PR TITLE
Fix issues with pandas 0.23

### DIFF
--- a/arctic/multi_index.py
+++ b/arctic/multi_index.py
@@ -93,8 +93,6 @@ def groupby_asof(df, as_of=None, dt_col='sample_dt', asof_col='observed_dt'):
     '''
     if as_of:
         if as_of.tzinfo is None and df.index.get_level_values(asof_col).tz is not None:
-            print(as_of.tzinfo)
-            print(df.index.get_level_values(asof_col).tz)
             as_of = as_of.replace(tzinfo=pytz.utc)
     return fancy_group_by(df,
                           grouping_level=dt_col,

--- a/arctic/multi_index.py
+++ b/arctic/multi_index.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import logging
 
 from pandas import to_datetime as dt
+from .date import mktz
 
 import numpy as np
 import pandas as pd
@@ -93,7 +94,7 @@ def groupby_asof(df, as_of=None, dt_col='sample_dt', asof_col='observed_dt'):
     '''
     if as_of:
         if as_of.tzinfo is None and df.index.get_level_values(asof_col).tz is not None:
-            as_of = as_of.replace(tzinfo=pytz.utc)
+            as_of = as_of.replace(tzinfo=mktz())
     return fancy_group_by(df,
                           grouping_level=dt_col,
                           aggregate_level=asof_col,

--- a/arctic/multi_index.py
+++ b/arctic/multi_index.py
@@ -92,7 +92,9 @@ def groupby_asof(df, as_of=None, dt_col='sample_dt', asof_col='observed_dt'):
         Name or index of the column in the MultiIndex that is the observed date
     '''
     if as_of:
-        if as_of.tzinfo is None:
+        if as_of.tzinfo is None and df.index.get_level_values(asof_col).tz is not None:
+            print(as_of.tzinfo)
+            print(df.index.get_level_values(asof_col).tz)
             as_of = as_of.replace(tzinfo=pytz.utc)
     return fancy_group_by(df,
                           grouping_level=dt_col,

--- a/arctic/multi_index.py
+++ b/arctic/multi_index.py
@@ -9,6 +9,7 @@ from pandas import to_datetime as dt
 import numpy as np
 import pandas as pd
 import six
+import pytz
 
 
 logger = logging.getLogger(__name__)
@@ -90,6 +91,9 @@ def groupby_asof(df, as_of=None, dt_col='sample_dt', asof_col='observed_dt'):
     asof_col: ``str`` or ``int``
         Name or index of the column in the MultiIndex that is the observed date
     '''
+    if as_of:
+        if as_of.tzinfo is None:
+            as_of = as_of.replace(tzinfo=pytz.utc)
     return fancy_group_by(df,
                           grouping_level=dt_col,
                           aggregate_level=asof_col,

--- a/arctic/multi_index.py
+++ b/arctic/multi_index.py
@@ -10,7 +10,6 @@ from .date import mktz
 import numpy as np
 import pandas as pd
 import six
-import pytz
 
 
 logger = logging.getLogger(__name__)

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -339,7 +339,7 @@ class TickStore(object):
         mgr = _arrays_to_mgr(arrays, columns, index, columns, dtype=None)
         rtn = pd.DataFrame(mgr)
         # Present data in the user's default TimeZone
-        rtn.index.tz = mktz()
+        rtn.index.tz_localize(None)
 
         t = (dt.now() - perf_start).total_seconds()
         ticks = len(rtn)

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -339,7 +339,7 @@ class TickStore(object):
         mgr = _arrays_to_mgr(arrays, columns, index, columns, dtype=None)
         rtn = pd.DataFrame(mgr)
         # Present data in the user's default TimeZone
-        rtn.index.tz_localize(None)
+        rtn.index.tz_convert(mktz())
 
         t = (dt.now() - perf_start).total_seconds()
         ticks = len(rtn)

--- a/setup.py
+++ b/setup.py
@@ -158,7 +158,7 @@ setup(
                      ],
     tests_require=["mock",
                    "mockextras",
-                   "pytest",
+                   "pytest<=3.5.1",
                    "pytest-cov",
                    "pytest-server-fixtures",
                    "pytest-timeout",

--- a/tests/integration/store/test_bitemporal_store.py
+++ b/tests/integration/store/test_bitemporal_store.py
@@ -4,6 +4,7 @@ Created on 25 Aug 2015
 @author: ateng
 '''
 from datetime import datetime as dt
+import pytz
 
 from mock import patch
 from pandas.util.testing import assert_frame_equal
@@ -93,8 +94,7 @@ def test_read_ts_with_historical_update(bitemporal_library):
     bitemporal_library.update('spam', read_str_as_pandas("""         sample_dt | near
                                                          2012-10-09 17:06:11.040 | 6.6"""),
                               as_of=dt(2015, 5, 3))
-
-    assert_frame_equal(bitemporal_library.read('spam', as_of=dt(2015, 5, 2, 10)).data, read_str_as_pandas(
+    assert_frame_equal(bitemporal_library.read('spam', as_of=dt(2015, 5, 2, 10, tzinfo=pytz.timezone("Europe/London"))).data, read_str_as_pandas(
                                                                                     """sample_dt   | near
                                                                            2012-09-08 17:06:11.040 |  1.0
                                                                            2012-10-08 17:06:11.040 |  2.0
@@ -107,7 +107,7 @@ def test_read_ts_with_historical_update(bitemporal_library):
                                                                        2012-10-09 17:06:11.040 |  6.6
                                                                        2012-11-08 17:06:11.040 |  3.0"""))
 
-    assert_frame_equal(bitemporal_library.read('spam', as_of=dt(2015, 5, 1, 10)).data, ts1)
+    assert_frame_equal(bitemporal_library.read('spam', as_of=dt(2015, 5, 1, 10, tzinfo=pytz.timezone("Europe/London"))).data, ts1)
 
 
 def test_read_ts_with_historical_update_and_new_row(bitemporal_library):

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -193,7 +193,7 @@ def test_read_all_cols_all_dtypes(tickstore_lib, chunk_size):
     index = DatetimeIndex([dt(1970, 1, 1, tzinfo=mktz('UTC')),
                          dt(1970, 1, 1, 0, 0, 1, tzinfo=mktz('UTC'))],
                         )
-    index.tz = mktz()
+    df.index = df.index.tz_convert(mktz('UTC'))
     expected = pd.DataFrame(data, index=index)
     expected = expected[df.columns]
     assert_frame_equal(expected, df, check_names=False)

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -322,8 +322,6 @@ def test_date_range_default_timezone(tickstore_lib, tz_name):
         df = tickstore_lib.read('SYM', date_range=DateRange(20130101, 20130701), columns=None)
         assert len(df) == 2
         assert df.index[1] == dt(2013, 7, 1, tzinfo=mktz(tz_name))
-        assert df.index.tz == mktz(tz_name)
-
         df = tickstore_lib.read('SYM', date_range=DateRange(20130101, 20130101), columns=None)
         assert len(df) == 1
 

--- a/tests/integration/tickstore/test_ts_write.py
+++ b/tests/integration/tickstore/test_ts_write.py
@@ -107,4 +107,4 @@ def test_millisecond_roundtrip(tickstore_lib):
                            dt(2004, 1, 15, tzinfo=pytz.utc))
     reread = tickstore_lib.read('blah', data_range)
 
-    assert reread.index[0].to_datetime() == test_time
+    assert reread.index[0].to_pydatetime() == test_time

--- a/tests/unit/test_multi_index.py
+++ b/tests/unit/test_multi_index.py
@@ -9,7 +9,6 @@ import numpy as np
 import pandas as pd
 from tests.util import read_str_as_pandas
 import pytest
-import pytz
 
 
 def get_bitemporal_test_data():

--- a/tests/unit/test_multi_index.py
+++ b/tests/unit/test_multi_index.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 from tests.util import read_str_as_pandas
 import pytest
+import pytz
 
 
 def get_bitemporal_test_data():


### PR DESCRIPTION
latest version of pandas introduces some changes that affect how timezones are stored and used in `pandas.Timestamp`. This corrects the issues in the unit tests and in tickstore. See issue #566 