### PR TITLE
fix failing integration tests on travis due to list_collection_names deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Arctic storage implementations are **pluggable**.  VersionStore is the default.
 Arctic currently works with:
 
  * Python 2.7, 3.4, 3.5, 3.6
- * pymongo >= 3.0
+ * pymongo >= 3.6
  * Pandas
  * MongoDB >= 2.4.x
 
@@ -137,6 +137,7 @@ It wouldn't be possible without the work of the AHL Data Engineering Team includ
  * [Wilfred Hughes](https://github.com/wilfred)
  * [Edward Easton](https://github.com/eeaston)
  * [Bryant Moscon](https://github.com/bmoscon)
+ * [Dimosthenis Pediaditakis](https://github.com/dimosped)
  * ... and many others ...
 
 Contributions welcome!

--- a/arctic/_util.py
+++ b/arctic/_util.py
@@ -1,9 +1,21 @@
 from pandas import DataFrame
 from pandas.util.testing import assert_frame_equal
-from pymongo.errors import OperationFailure
 import logging
+import pymongo
+
 
 logger = logging.getLogger(__name__)
+
+# Avoid import-time extra logic
+_use_new_count_api = None
+
+
+def _detect_new_count_api():
+    try:
+        mongo_v = [int(v) for v in pymongo.version.split('.')]
+        return mongo_v[0] >= 3 and mongo_v[1] >= 7
+    except:
+        return False
 
 
 def indent(s, num_spaces):
@@ -47,7 +59,7 @@ def enable_sharding(arctic, library_name, hashed=True, key='symbol'):
     library_name = lib.get_top_level_collection().name
     try:
         c.admin.command('enablesharding', dbname)
-    except OperationFailure as e:
+    except pymongo.errors.OperationFailure as e:
         if 'already enabled' not in str(e):
             raise
     if not hashed:
@@ -56,3 +68,15 @@ def enable_sharding(arctic, library_name, hashed=True, key='symbol'):
     else:
         logger.info("Hash sharding '" + key + "' on: " + dbname + '.' + library_name)
         c.admin.command('shardCollection', dbname + '.' + library_name, key={key: 'hashed'})
+
+
+def mongo_count(collection, filter=None, **kwargs):
+    filter = {} if filter is None else filter
+    global _use_new_count_api
+    _use_new_count_api = _detect_new_count_api() if _use_new_count_api is None else _use_new_count_api
+    # This is a temporary compatibility fix for compatibility with pymongo>=3.7, and also avoid deprecation warnings
+    if _use_new_count_api:
+        # Projection is ignored for count_documents
+        return collection.count_documents(filter=filter, **kwargs)
+    else:
+        return collection.count(filter=filter, **kwargs)

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -181,11 +181,11 @@ class Arctic(object):
         libs = []
         for db in self._conn.list_database_names():
             if db.startswith(self.DB_PREFIX + '_'):
-                for coll in self._conn[db].collection_names():
+                for coll in self._conn[db].list_collection_names():
                     if coll.endswith(self.METADATA_COLL):
                         libs.append(db[len(self.DB_PREFIX) + 1:] + "." + coll[:-1 * len(self.METADATA_COLL) - 1])
             elif db == self.DB_PREFIX:
-                for coll in self._conn[db].collection_names():
+                for coll in self._conn[db].list_collection_names():
                     if coll.endswith(self.METADATA_COLL):
                         libs.append(coll[:-1 * len(self.METADATA_COLL) - 1])
         return libs
@@ -212,9 +212,9 @@ class Arctic(object):
         # check that we don't create too many namespaces
         # can be disabled check_library_count=False
         check_library_count = kwargs.pop('check_library_count', True)
-        if len(self._conn[l.database_name].collection_names()) > 5000 and check_library_count:
+        if len(self._conn[l.database_name].list_collection_names()) > 5000 and check_library_count:
             raise ArcticException("Too many namespaces %s, not creating: %s" %
-                                  (len(self._conn[l.database_name].collection_names()), library))
+                                  (len(self._conn[l.database_name].list_collection_names()), library))
         l.set_library_type(lib_type)
         LIBRARY_TYPES[lib_type].initialize_library(l, **kwargs)
         # Add a 10G quota just in case the user is calling this with API.
@@ -233,11 +233,11 @@ class Arctic(object):
         """
         l = ArcticLibraryBinding(self, library)
         colname = l.get_top_level_collection().name
-        if not [c for c in l._db.collection_names(False) if re.match(r"^{}([\.].*)?$".format(colname), c)]:
+        if not [c for c in l._db.list_collection_names(False) if re.match(r"^{}([\.].*)?$".format(colname), c)]:
             logger.info('Nothing to delete. Arctic library %s does not exist.' % colname)
         logger.info('Dropping collection: %s' % colname)
         l._db.drop_collection(colname)
-        for coll in l._db.collection_names():
+        for coll in l._db.list_collection_names():
             if coll.startswith(colname + '.'):
                 logger.info('Dropping collection: %s' % coll)
                 l._db.drop_collection(coll)
@@ -352,7 +352,7 @@ class Arctic(object):
 
         logger.info('Renaming collection: %s' % colname)
         l._db[colname].rename(to_colname)
-        for coll in l._db.collection_names():
+        for coll in l._db.list_collection_names():
             if coll.startswith(colname + '.'):
                 l._db[coll].rename(coll.replace(colname, to_colname))
 

--- a/arctic/fixtures/arctic.py
+++ b/arctic/fixtures/arctic.py
@@ -324,6 +324,12 @@ def user_library(arctic, user_library_name):
 def overlay_library(arctic, overlay_library_name):
     """ Overlay library fixture, returns a pair of libs, read-write: ${name} and read-only: ${name}_RAW
     """
+    # Call _create_overlay_library to avoid:
+    #  RemovedInPytest4Warning: Fixture overlay_library called directly. Fixtures are not meant to be called directly
+    return _overlay_library(arctic, overlay_library)
+
+
+def _overlay_library(arctic, overlay_library_name):
     rw_name = overlay_library_name
     ro_name = '{}_RAW'.format(overlay_library_name)
     arctic.initialize_library(rw_name, m.VERSION_STORE, segment='year')
@@ -333,6 +339,12 @@ def overlay_library(arctic, overlay_library_name):
 
 @pytest.fixture(scope="function")
 def tickstore_lib(arctic, library_name):
+    # Call _create_overlay_library to avoid:
+    #  RemovedInPytest4Warning: Fixture overlay_library called directly. Fixtures are not meant to be called directly
+    return _tickstore_lib(arctic, library_name)
+
+
+def _tickstore_lib(arctic, library_name):
     arctic.initialize_library(library_name, TICK_STORE_TYPE)
     return arctic.get_library(library_name)
 

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -8,6 +8,7 @@ import numpy as np
 import pymongo
 from pymongo.errors import OperationFailure, DuplicateKeyError
 
+from arctic._util import mongo_count
 from ..decorators import mongo_retry
 from ..exceptions import UnhandledDtypeException, DataIntegrityException
 from ._version_store_utils import checksum, version_base_or_id, _fast_check_corruption
@@ -455,8 +456,7 @@ class NdarrayStore(object):
         parent_id = version_base_or_id(version)
 
         # Check all the chunks are in place
-        seen_chunks = collection.find({'symbol': symbol, 'parent': parent_id},
-                                      ).count()
+        seen_chunks = mongo_count(collection, filter={'symbol': symbol, 'parent': parent_id})
 
         if seen_chunks != version['segment_count']:
             segments = [x['segment'] for x in collection.find({'symbol': symbol, 'parent': parent_id},

--- a/arctic/store/bson_store.py
+++ b/arctic/store/bson_store.py
@@ -1,7 +1,7 @@
 import logging
 from pymongo.errors import OperationFailure
 from ..decorators import mongo_retry
-from .._util import enable_sharding
+from .._util import enable_sharding, mongo_count
 
 logger = logging.getLogger(__name__)
 
@@ -161,7 +161,7 @@ class BSONStore(object):
         """
         See http://api.mongodb.com/python/current/api/pymongo/collection.html#pymongo.collection.Collection.count
         """
-        return self._collection.count(filter, **kwargs)
+        return mongo_count(self._collection, filter=filter, **kwargs)
 
     @mongo_retry
     def aggregate(self, pipeline, **kwargs):

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -2,6 +2,8 @@ from pandas import DataFrame, MultiIndex, Index, Series
 from datetime import datetime as dt
 from datetime import timedelta
 from pandas.util.testing import assert_frame_equal, assert_series_equal
+
+from arctic._util import mongo_count
 from arctic.date import DateRange
 from arctic.exceptions import NoDataFoundException
 import pandas as pd
@@ -943,7 +945,7 @@ def test_delete_range_segment(chunkstore_lib):
     chunkstore_lib.delete('test_df', chunk_range=pd.date_range(dt(2016, 1, 1), dt(2016, 1, 1)))
     read_df = chunkstore_lib.read('test_df')
     assert(read_df.equals(dg))
-    assert(chunkstore_lib._collection.count({'sy': 'test_df'}) == 1)
+    assert(mongo_count(chunkstore_lib._collection, {'sy': 'test_df'}) == 1)
 
 
 def test_size_chunk_update(chunkstore_lib):
@@ -960,7 +962,7 @@ def test_size_chunk_update(chunkstore_lib):
     read_df = chunkstore_lib.read('test_df')
 
     assert_frame_equal(dh, read_df)
-    assert(chunkstore_lib._collection.count({'sy': 'test_df'}) == 1)
+    assert mongo_count(chunkstore_lib._collection, filter={'sy': 'test_df'}) == 1
 
 
 def test_size_chunk_multiple_update(chunkstore_lib):
@@ -976,7 +978,7 @@ def test_size_chunk_multiple_update(chunkstore_lib):
     expected = pd.concat([df_large, df_small]).reset_index(drop=True)
 
     assert_frame_equal(expected, read_df)
-    assert(chunkstore_lib._collection.count({'sy': 'test_df'}) == 3)
+    assert mongo_count(chunkstore_lib._collection, filter={'sy': 'test_df'}) == 3
 
 
 def test_get_chunk_range(chunkstore_lib):

--- a/tests/integration/store/test_ndarray_store.py
+++ b/tests/integration/store/test_ndarray_store.py
@@ -6,6 +6,7 @@ from numpy.testing import assert_equal
 from pymongo.server_type import SERVER_TYPE
 import pytest
 
+from arctic._util import mongo_count
 from arctic.store._ndarray_store import NdarrayStore, _APPEND_COUNT
 from arctic.store.version_store import register_versioned_storage
 
@@ -57,7 +58,7 @@ def test_save_and_resave_reuses_chunks(library):
         library.write('MYARR', ndarr)
         saved_arr = library.read('MYARR').data
         assert np.all(ndarr == saved_arr)
-        orig_chunks = library._collection.count()
+        orig_chunks = mongo_count(library._collection)
         assert orig_chunks == 9
 
         # Concatenate more values
@@ -70,11 +71,11 @@ def test_save_and_resave_reuses_chunks(library):
 
         # Should contain the original chunks, but not double the number
         # of chunks
-        new_chunks = library._collection.count()
+        new_chunks = mongo_count(library._collection)
         assert new_chunks == 11
 
         # We hit the update (rather than upsert) code path
-        assert library._collection.find({'parent': {'$size': 2}}).count() == 7
+        assert mongo_count(library._collection, filter={'parent': {'$size': 2}}) == 7
 
 
 def test_save_read_big_2darray(library):

--- a/tests/integration/store/test_pickle_store.py
+++ b/tests/integration/store/test_pickle_store.py
@@ -3,6 +3,7 @@ from datetime import datetime as dt, timedelta
 from mock import patch
 import numpy as np
 
+from arctic._util import mongo_count
 from arctic.arctic import Arctic
 
 
@@ -57,11 +58,11 @@ def test_bson_large_object(library):
 def test_bson_leak_objects_delete(library):
     blob = {'foo': dt(2015, 1, 1), 'object': Arctic}
     library.write('BLOB', blob)
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 1
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 1
     library.delete('BLOB')
-    assert library._collection.count() == 0
-    assert library._collection.versions.count() == 0
+    assert mongo_count(library._collection) == 0
+    assert mongo_count(library._collection.versions) == 0
 
 
 def test_bson_leak_objects_prune_previous(library):
@@ -71,19 +72,19 @@ def test_bson_leak_objects_prune_previous(library):
     _id = bson.ObjectId.from_datetime(yesterday)
     with patch("bson.ObjectId", return_value=_id):
         library.write('BLOB', blob)
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 1
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 1
 
     _id = bson.ObjectId.from_datetime(dt.utcnow() - timedelta(minutes=130))
     with patch("bson.ObjectId", return_value=_id):
         library.write('BLOB', {}, prune_previous_version=False)
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 2
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 2
 
     # This write should pruned the oldest version in the chunk collection
     library.write('BLOB', {})
-    assert library._collection.count() == 0
-    assert library._collection.versions.count() == 2
+    assert mongo_count(library._collection) == 0
+    assert mongo_count(library._collection.versions) == 2
 
 
 def test_prune_previous_doesnt_kill_other_objects(library):
@@ -93,23 +94,23 @@ def test_prune_previous_doesnt_kill_other_objects(library):
     _id = bson.ObjectId.from_datetime(yesterday)
     with patch("bson.ObjectId", return_value=_id):
         library.write('BLOB', blob, prune_previous_version=False)
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 1
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 1
 
     _id = bson.ObjectId.from_datetime(dt.utcnow() - timedelta(hours=10))
     with patch("bson.ObjectId", return_value=_id):
         library.write('BLOB', blob, prune_previous_version=False)
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 2
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 2
 
     # This write should pruned the oldest version in the chunk collection
     library.write('BLOB', {})
-    assert library._collection.count() == 1
-    assert library._collection.versions.count() == 2
+    assert mongo_count(library._collection) == 1
+    assert mongo_count(library._collection.versions) == 2
 
     library._delete_version('BLOB', 2)
-    assert library._collection.count() == 0
-    assert library._collection.versions.count() == 1
+    assert mongo_count(library._collection) == 0
+    assert mongo_count(library._collection.versions) == 1
 
 
 def test_write_metadata(library):

--- a/tests/integration/store/test_version_store_audit.py
+++ b/tests/integration/store/test_version_store_audit.py
@@ -5,6 +5,7 @@ from pandas.util.testing import assert_frame_equal
 from pymongo.errors import OperationFailure
 import pytest
 
+from arctic._util import mongo_count
 from arctic.store.audit import ArcticTransaction
 from arctic.exceptions import ConcurrentModificationException, NoDataFoundException
 
@@ -172,9 +173,9 @@ def test_cleanup_orphaned_versions_integration(library):
     with patch('bson.ObjectId', return_value=_id):
         with ArcticTransaction(library, symbol, 'u1', 'l1') as mt:
             mt.write(symbol, ts1)
-    assert library._versions.find({'parent': {'$size': 1}}).count() == 1
+    assert mongo_count(library._versions, filter={'parent': {'$size': 1}}) == 1
     library._cleanup_orphaned_versions(False)
-    assert library._versions.find({'parent': {'$size': 1}}).count() == 1
+    assert mongo_count(library._versions, filter={'parent': {'$size': 1}}) == 1
 
 
 def test_corrupted_read_writes_new(library):

--- a/tests/integration/store/test_version_store_corruption.py
+++ b/tests/integration/store/test_version_store_corruption.py
@@ -256,7 +256,7 @@ def test_fast_is_safe_to_append(library, library_name):
     def modify_segment(segment, item):
         segment['segment'] -= 2
         sha = hashlib.sha1()
-        sha.update(item)
+        sha.update(item.encode('ascii'))
         segment['sha'] = Binary(sha.digest())
         segment.pop('_id')
         

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -132,20 +132,20 @@ def test_delete_library(arctic, library, library_name):
     # create a library2 library too - ensure that this isn't deleted
     arctic.initialize_library('user.library2', VERSION_STORE, segment='month')
     library.write('asdf', get_large_ts(1))
-    assert 'TEST' in mongo.arctic_test.collection_names()
-    assert 'TEST.versions' in mongo.arctic_test.collection_names()
-    assert 'library2' in mongo.arctic_user.collection_names()
-    assert 'library2.versions' in mongo.arctic_user.collection_names()
+    assert 'TEST' in mongo.arctic_test.list_collection_names()
+    assert 'TEST.versions' in mongo.arctic_test.list_collection_names()
+    assert 'library2' in mongo.arctic_user.list_collection_names()
+    assert 'library2.versions' in mongo.arctic_user.list_collection_names()
 
     arctic.delete_library(library_name)
-    assert 'TEST' not in mongo.arctic_user.collection_names()
-    assert 'TEST.versions' not in mongo.arctic_user.collection_names()
+    assert 'TEST' not in mongo.arctic_user.list_collection_names()
+    assert 'TEST.versions' not in mongo.arctic_user.list_collection_names()
     with pytest.raises(LibraryNotFoundException):
         arctic[library_name]
     with pytest.raises(LibraryNotFoundException):
         arctic['arctic_{}'.format(library_name)]
-    assert 'library2' in mongo.arctic_user.collection_names()
-    assert 'library2.versions' in mongo.arctic_user.collection_names()
+    assert 'library2' in mongo.arctic_user.list_collection_names()
+    assert 'library2.versions' in mongo.arctic_user.list_collection_names()
 
 
 def test_quota(arctic, library, library_name):

--- a/tests/integration/test_compress_integration.py
+++ b/tests/integration/test_compress_integration.py
@@ -63,10 +63,10 @@ def test_exceptions():
     data = data[0:16]
     with pytest.raises(Exception) as e:
         c.decompress(data)
-    assert("Decompressor wrote" in str(e) or "Corrupt input at" in str(e))
+    assert("decompressor wrote" in str(e).lower() or "corrupt input at" in str(e).lower() or "decompression failed: corrupt input" in str(e).lower())
 
     data = c.compress(b'1010101010100000000000000000000000000000000000000000000000000000000011111111111111111111111111111')
     data = [data[0:16] for x in (1, 2, 3)]
     with pytest.raises(Exception) as e:
         c.decompress_array(data)
-    assert ("Decompressor wrote" in str(e) or "Corrupt input at" in str(e))
+    assert ("decompressor wrote" in str(e).lower() or "corrupt input at" in str(e).lower() or "decompression failed: corrupt input" in str(e).lower())

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -11,6 +11,7 @@ import pytest
 import pytz
 import six
 
+from arctic._util import mongo_count
 from arctic.date import DateRange, mktz, CLOSED_CLOSED, CLOSED_OPEN, OPEN_CLOSED, OPEN_OPEN
 from arctic.exceptions import NoDataFoundException
 
@@ -241,31 +242,31 @@ def test_date_range(tickstore_lib):
     with patch('pymongo.collection.Collection.find', side_effect=tickstore_lib._collection.find) as f:
         df = tickstore_lib.read('SYM', date_range=DateRange(20130101, 20130103), columns=None)
         assert_array_equal(df['b'].values, np.array([2., 3., 5.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 1
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 1
         df = tickstore_lib.read('SYM', date_range=DateRange(20130102, 20130103), columns=None)
         assert_array_equal(df['b'].values, np.array([3., 5.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 1
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 1
         df = tickstore_lib.read('SYM', date_range=DateRange(20130103, 20130103), columns=None)
         assert_array_equal(df['b'].values, np.array([5.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 1
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 1
 
         df = tickstore_lib.read('SYM', date_range=DateRange(20130102, 20130104), columns=None)
         assert_array_equal(df['b'].values, np.array([3., 5., 7.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 2
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 2
         df = tickstore_lib.read('SYM', date_range=DateRange(20130102, 20130105), columns=None)
         assert_array_equal(df['b'].values, np.array([3., 5., 7., 9.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 2
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 2
 
         df = tickstore_lib.read('SYM', date_range=DateRange(20130103, 20130104), columns=None)
         assert_array_equal(df['b'].values, np.array([5., 7.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 2
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 2
         df = tickstore_lib.read('SYM', date_range=DateRange(20130103, 20130105), columns=None)
         assert_array_equal(df['b'].values, np.array([5., 7., 9.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 2
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 2
 
         df = tickstore_lib.read('SYM', date_range=DateRange(20130104, 20130105), columns=None)
         assert_array_equal(df['b'].values, np.array([7., 9.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 1
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 1
 
         # Test the different open-closed behaviours
         df = tickstore_lib.read('SYM', date_range=DateRange(20130104, 20130105, CLOSED_CLOSED), columns=None)
@@ -295,7 +296,7 @@ def test_date_range_end_not_in_range(tickstore_lib):
     with patch.object(tickstore_lib._collection, 'find', side_effect=tickstore_lib._collection.find) as f:
         df = tickstore_lib.read('SYM', date_range=DateRange(20130101, dt(2013, 1, 2, 9, 0)), columns=None)
         assert_array_equal(df['b'].values, np.array([2.]))
-        assert tickstore_lib._collection.find(f.call_args_list[-1][0][0]).count() == 1
+        assert mongo_count(tickstore_lib._collection, filter=f.call_args_list[-1][0][0]) == 1
 
 
 @pytest.mark.parametrize('tz_name', ['UTC',

--- a/tests/unit/store/test_bson_store.py
+++ b/tests/unit/store/test_bson_store.py
@@ -2,7 +2,7 @@ from arctic.store.bson_store import BSONStore
 from arctic.arctic import ArcticLibraryBinding
 from arctic import Arctic
 from pymongo.collection import Collection
-from mock import sentinel, create_autospec, patch, call
+from mock import sentinel, create_autospec, patch, call, Mock
 
 
 def test_initialize_library():
@@ -174,14 +174,14 @@ def test_delete_one():
 
 def test_count():
     arctic_lib = create_autospec(ArcticLibraryBinding, instance=True)
-    collection = create_autospec(Collection, instance=True)
+    collection = create_autospec(Collection, instance=True, count=Mock(), count_documents=Mock())
     arctic_lib.get_top_level_collection.return_value = collection
 
     bsons = BSONStore(arctic_lib)
     bsons.count(sentinel.filter)
 
-    assert collection.count.call_count == 1
-    assert collection.count.call_args_list == [call(sentinel.filter)]
+    assert collection.count.call_count + collection.count_documents.call_count == 1
+    assert collection.count.call_args_list == [call(filter=sentinel.filter)] or collection.count_documents.call_args_list == [call(filter=sentinel.filter)]
 
 
 def test_distinct():

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -171,6 +171,8 @@ def test_initialize_library():
     with patch('arctic.store.version_store.enable_sharding', autospec=True) as enable_sharding:
         arctic_lib.get_top_level_collection.return_value.database.create_collection.__name__ = 'some_name'
         arctic_lib.get_top_level_collection.return_value.database.collection_names.__name__ = 'some_name'
+        arctic_lib.get_top_level_collection.__name__ = 'get_top_level_collection'
+        arctic_lib.get_top_level_collection.return_value.database.list_collection_names.__name__ = 'list_collection_names'
         VersionStore.initialize_library(arctic_lib, hashed=sentinel.hashed)
     assert enable_sharding.call_args_list == [call(arctic_lib.arctic, arctic_lib.get_name(), hashed=sentinel.hashed)]
 

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -285,7 +285,7 @@ def test_initialize_library_too_many_ns():
     self._conn = create_autospec(MongoClient)
     lib = create_autospec(ArcticLibraryBinding)
     lib.database_name = sentinel.db_name
-    self._conn.__getitem__.return_value.collection_names.return_value = [x for x in six.moves.xrange(5001)]
+    self._conn.__getitem__.return_value.list_collection_names.return_value = [x for x in six.moves.xrange(5001)]
     lib_type = Mock()
     with pytest.raises(ArcticException) as e:
         with patch.dict('arctic.arctic.LIBRARY_TYPES', {sentinel.lib_type: lib_type}), \
@@ -303,7 +303,7 @@ def test_initialize_library():
     lib = create_autospec(ArcticLibraryBinding)
     lib.database_name = sentinel.db_name
     lib.get_quota.return_value = None
-    self._conn.__getitem__.return_value.collection_names.return_value = [x for x in six.moves.xrange(5001)]
+    self._conn.__getitem__.return_value.list_collection_names.return_value = [x for x in six.moves.xrange(5001)]
     lib_type = Mock()
     with patch.dict('arctic.arctic.LIBRARY_TYPES', {sentinel.lib_type: lib_type}), \
          patch('arctic.arctic.ArcticLibraryBinding', return_value=lib, autospec=True) as ML:

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -3,18 +3,18 @@ from mock import Mock
 from arctic.arctic import Arctic
 
 
-def test_overlay_library_name():
-    assert(fix.overlay_library_name() == 'test.OVERLAY')
+def test_overlay_library_name(overlay_library_name):
+    assert(overlay_library_name == 'test.OVERLAY')
 
 
 def test_overlay_library():
     a = Mock(Arctic, autospec=True)
-    fix.overlay_library(a, "test")
+    fix._overlay_library(a, 'test')
     a.initialize_library.assert_called_with("test_RAW", "VersionStore", segment='year')
 
 
 def test_tickstore_lib():
     a = Mock(Arctic, autospec=True)
-    fix.tickstore_lib(a, "test")
+    fix._tickstore_lib(a, "test")
     a.initialize_library.assert_called_with('test', 'TickStoreV3')
-    a.get_library.assert_called_with('test') 
+    a.get_library.assert_called_with('test')


### PR DESCRIPTION
Fixes issues #596 and #599

list_collection_names was added with pymongo 3.6.0:
https://github.com/mongodb/mongo-python-driver/blob/3.6.0/pymongo/database.py#L590

We switched to requiring pymongo>=3.6.0 recently:
https://github.com/manahl/arctic/blob/master/setup.py#L86

Therefore it is safe to simply replace collection_names with list_collection_names