### PR TITLE
Version store documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   * Bugfix: #591 Fix tickstore reads not returning index with localized timezone
   * Feature: #595 add host attribute to VersionedItem.'
   * Bugfix: #594 Enable sharding on chunkstore
+  * Docs: VersionStore documentation
 
 ### 1.67.1 (2018-07-11)
   * Bugfix: #579 Fix symbol corruption due to restore_version and append

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,9 @@
 ## Changelog
 
-### 1.68
+### 1.69
+  * Docs: VersionStore documentation
+
+### 1.68 (2018-08-17)
   * Feature: #553 Compatibility with both the new and old LZ4 API
   * Feature: #571 Removed the Cython LZ4 code, use the latest python-lz4
   * Feature: #557 Threadpool based compression. Speed imrpovement and tuning benchmarks.
@@ -8,7 +11,6 @@
   * Bugfix: #591 Fix tickstore reads not returning index with localized timezone
   * Feature: #595 add host attribute to VersionedItem.'
   * Bugfix: #594 Enable sharding on chunkstore
-  * Docs: VersionStore documentation
 
 ### 1.67.1 (2018-07-11)
   * Bugfix: #579 Fix symbol corruption due to restore_version and append

--- a/README.md
+++ b/README.md
@@ -98,10 +98,12 @@ Arctic includes three storage engines:
       * Audited writes: API for saving metadata and data before and after a write.
       * a wide range of TimeSeries data frequencies: End-Of-Day to Minute bars
       * [See the HowTo](howtos/how_to_use_arctic.py)
+      * [Documentation](docs/versionstore.md)
   * [TickStore](arctic/tickstore/tickstore.py): Column oriented tick database.  Supports
     dynamic fields, chunks aren't versioned. Designed for large continuously ticking data.
   * [Chunkstore](https://github.com/manahl/arctic/wiki/Chunkstore): A storage type that allows data to be stored in customizable chunk sizes. Chunks
     aren't versioned, and can be appended to and updated in place. 
+    * [Documentation](docs/chunkstore.md)
 
 Arctic storage implementations are **pluggable**.  VersionStore is the default.
 

--- a/docs/chunkstore.md
+++ b/docs/chunkstore.md
@@ -2,7 +2,7 @@
 
 (note: current doc is based on arctic-1.31.0)
 
-Chunkstore serializes and store Pandas Dataframes and Series into user defined chunks in MongoDB. Retrieving specific chunks, or ranges of chunks, is very fast and efficient. Chunkstore is optimized more for reading than for writing, and is ideal for use cases when very large datasets need to be accessed by 'chunk'.
+Chunkstore serializes and stores Pandas Dataframes and Series into user defined chunks in MongoDB. Retrieving specific chunks, or ranges of chunks, is very fast and efficient. Chunkstore is optimized more for reading than for writing, and is ideal for use cases when very large datasets need to be accessed by 'chunk'.
 
 Chunkstore supports pluggable serializers. A Serializer is used to convert the Pandas datatype into something that can be efficiently stored by Mongo. Chunkstore's default serializer is the [FrameConverter](https://github.com/manahl/arctic/blob/master/arctic/serialization/numpy_arrays.py#L22) which works by converting each column in the dataframe to a compressed Numpy array. Columns can be retrieved individually this way, without deserializing the other columns in the dataframe. 
 

--- a/docs/chunkstore.md
+++ b/docs/chunkstore.md
@@ -9,7 +9,7 @@ Chunkstore supports pluggable serializers. A Serializer is used to convert the P
 Chunkstore also supports pluggable chunkers. A chunker takes the dataframe and converts it into chunks. Chunks are stored individually in Mongo for easy retrieval by chunk. Chunkstore currently has two chunkers: [DateRange Chunker](https://github.com/manahl/arctic/blob/master/arctic/chunkstore/date_chunker.py) and [PassThrough Chunker](https://github.com/manahl/arctic/blob/master/arctic/chunkstore/passthrough_chunker.py). The DateRange chunker chunks a dataframe by a datetime index or column. Currently it must be called 'date'. It chunks by a period, Daily, Monthly, or Yearly. The data can be retrieved from Mongo for any date range, so for DateRange chunked data, its important that the chunking period (or size) be selected appropriately. If data will frequently be read in daily increments, choosing a Year chunk size doesn't really make sense and will be slower than data access of daily chunked data. The PassThrough chunker simply takes the dataframe and writes it to mongo. It does not chunk the data.
 
 
-# Reading and Writing Data Chunkstore
+# Reading and Writing Data with Chunkstore
 
 ```
 from arctic import CHUNK_STORE, Arctic

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -112,7 +112,7 @@ date       id  data
 
 ```
 
-
+DateRange's only apply to pandas DataFrames, and the dataframe must have a datetime index present. 
 
 
 

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -140,8 +140,65 @@ VersionedItem(symbol=new,library=arctic.vstore,data=<class 'NoneType'>,version=1
 
 ```
 
+Other Methods
+
+A number of other utility methods are available:
+
+* delete
+* has_symbol
+* list_versions
+* read_metadata
+* write_metadata
+* restore_version
+* snapshot
+* delete_snapshot
+* list_snapshots
+
+`delete` does what you might expect - it deletes a symbol from the library. It takes a single argument, `symbol`. `has_symbol` and `list_symbols` will return information about the current state of symbols in the library. Their signatures are:
+
+```
+list_symbols(self, all_symbols=False, snapshot=None, regex=None, **kwargs)
+
+def has_symbol(self, symbol, as_of=None)
+```
+
+for `list_symbols`, `all_symbols` if set to `true` will return all symbols, from all snapshots, even if the symbol has been deleted in the current version (but is saved in a snapshot). `snapshot` allows you to list symbols under a specified `snapshot`. `regex` allows you to supply a regular expression to further restrict the list of symbols returned from the query. Arctic uses MongoDB's `$regex` functionality. Mongo supports PERL syntax regex; more information is available [here](https://docs.mongodb.com/manual/reference/operator/query/regex/)
+
+`has_symbol` returns `True` or `False` based on wheter the symbol exists or not. You can restrict this check to a specific `version` via `as_of`. 
 
 
+```
+
+>>> lib.delete('new')
+
+>>> lib.list_symbols()
+['test']
+
+>>> lib.has_symbol('new')
+False
+
+>>> lib.write('test2', df)
+
+>>> lib.list_symbols(regex=".*2")
+['test2']
+
+```
+
+`read_metadata` and `write_metadata` allow you to read/set the user defined metadata directly for a given symbol. 
 
 
+```
+
+>>> lib.read_metadata('test2')
+VersionedItem(symbol=test2,library=arctic.vstore,data=<class 'NoneType'>,version=1,metadata=None,host=127.0.0.1)
+
+>>> lib.read_metadata('test2').metadata
+
+>>> lib.write_metadata('test2', {'meta': 'data'})
+VersionedItem(symbol=test2,library=arctic.vstore,data=<class 'NoneType'>,version=2,metadata={'meta': 'data'},host=127.0.0.1)
+
+>>> lib.read_metadata('test2').metadata
+Out[71]: {'meta': 'data'}
+
+```
 

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -1,6 +1,5 @@
 # VersionStore
 
-# Chunkstore Overview
 
 (note: current doc is based on arctic-1.68.0)
 

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -72,3 +72,43 @@ date       id
 * metadata - metadata if exists, or None
 * data (for writes this is None, for reads it contains the data read from the database).
 * host
+
+You should also note that VersionStore's `write` effectively overwrites already written data. In the above example, the second `write` replaced the data in symbol `test` with the new dataframe. The original data (version 1) is still available, but must be referenced by its version number in order to retrieve it. The `read` method takes the following arguments:
+
+```
+symbol, as_of=None, date_range=None, from_version=None, allow_secondary=None, **kwargs
+```
+
+`as_of` allows you to retrieve the data as it was at a specific point in time. You can define that point in time in a number of ways.
+
+* the name of a snapshot (string)
+* a version number (int)
+* a datetime (`datetime.datetime`)
+
+`date_range` lets you subset the data via an Arctic [DateRange](https://github.com/manahl/arctic/blob/master/arctic/date/_daterange.py#L15) object. `DateRange`s allows you to specify a date range ('2016-01-01', '2016-09-30') with start and end dates, as well as open ended ranges (None, '2016-09-30'). Ranges can be open at either end. `allow_secondary` lets you override the default behavior to allow or disallow reading from secondary members of the mongo cluster.
+
+
+```
+>>> lib.read('test').data
+               data
+date       id      
+2016-01-01 1    100
+2016-01-02 1    200
+2016-01-03 1    300
+
+>>> lib.read('test', as_of=1).data
+               
+date       id  data    
+2016-01-01 1      1
+2016-01-02 1      2
+2016-01-03 1      3
+
+
+```
+
+
+
+
+
+
+

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -104,6 +104,12 @@ date       id  data
 2016-01-03 1      3
 
 
+>>> from arctic.date import DateRange
+>>> lib.read('test', date_range=DateRange('2016-01-01', '2016-01-01')).data
+               
+date       id  data    
+2016-01-01 1    100
+
 ```
 
 

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -51,7 +51,7 @@ date       id
                                                names=['date', 'id']))
 
 >>> lib.write('test', df)
->>> lib.read('test')
+>>> lib.read('test').data
                data
 date       id      
 2016-01-01 1    100

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -1,3 +1,71 @@
-# Versionstore
+# VersionStore
 
-Coming soon
+# Chunkstore Overview
+
+(note: current doc is based on arctic-1.68.0)
+
+VersionStore serializes and stores Pandas objects, numpy arrays as well as other python types in MongoDB. Objects are `versioned` and new versions are created when a `symbol` is modified. 
+
+
+# Reading and Writing Data with VersionStore
+
+```
+from arctic import Arctic
+
+a = Arctic(‘localhost’)
+a.initialize_library('vstore')
+lib = a[‘vstore’]
+```
+
+At this point you have an empty VersionStore library. You do not need to specify the storage type because VersionStore is the default library type in Arctic. You can write data to it several ways. The most basic is to use the `write` method. [Write](https://github.com/manahl/arctic/blob/master/arctic/store/version_store.py#L563) takes the following arguments:
+
+`symbol, data, metadata=None, prune_previous_version=True, **kwargs`
+
+`symbol` is the name that is used to store/retrieve the data in Arctic. `data` is the data to be stored in MongoDB. `metadata` is optional user defined metadata. It must be a `dict`. `prune_previous_versions` will prune/remove previous versions of the data (provided they have not been included in a snapshot). `kwargs` are passed on to the individual write handler. There are write handlers for different data types.
+
+`write` is designed to write and replace data. If you write symbol `test` with one dataset and write it again with another, the original data will be replace with a new version of the data. 
+
+
+```
+>>> from pandas import DataFrame, MultiIndex
+>>> from datetime import datetime as dt
+
+
+>>> df = DataFrame(data={'data': [1, 2, 3]},
+                   index=MultiIndex.from_tuples([(dt(2016, 1, 1), 1),
+                                                 (dt(2016, 1, 2), 1),
+                                                 (dt(2016, 1, 3), 1)],
+                                                names=['date', 'id']))
+>>> lib.write('test', df)
+>>> lib.read('test').data
+               data
+date       id      
+2016-01-01 1      1
+2016-01-02 1      2
+2016-01-03 1      3
+
+
+>>> df = DataFrame(data={'data': [100, 200, 300]},
+                   index=MultiIndex.from_tuples([(dt(2016, 1, 1), 1),
+                                                 (dt(2016, 1, 2), 1),
+                                                 (dt(2016, 1, 3), 1)],
+                                               names=['date', 'id']))
+
+>>> lib.write('test', df)
+>>> lib.read('test')
+               data
+date       id      
+2016-01-01 1    100
+2016-01-02 1    200
+2016-01-03 1    300
+
+```
+
+`write` returns a `VersionedItem` object. `VersionedItem` contains the following members:
+
+* symbol
+* library
+* version
+* metadata
+* data
+* host

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -114,6 +114,33 @@ date       id  data
 
 DateRange's only apply to pandas DataFrames, and the dataframe must have a datetime index present. 
 
+Another way to write data is with the [`append`](https://github.com/manahl/arctic/blob/master/arctic/store/version_store.py#L473) method. `append` takes the following arguments:
+
+```
+symbol, data, metadata=None, prune_previous_version=True, upsert=True, **kwargs
+```
+
+`upsert` is the only new argument. `upsert` means that if the symbol does not exist, it will create it. If `upsert` were `False` an error would be raised as there would be no existing data to append to.
+
+```
+
+>>> lib.append('new', df, upsert=False)
+~/arctic/arctic/store/version_store.py in append(self, symbol, data, metadata, prune_previous_version, upsert, **kwargs)
+    505             return self.write(symbol=symbol, data=data, prune_previous_version=prune_previous_version, metadata=metadata)
+    506 
+--> 507         assert previous_version is not None
+    508         dirty_append = False
+    509 
+
+AssertionError: 
+
+
+>>> lib.append('new', df, upsert=True)
+VersionedItem(symbol=new,library=arctic.vstore,data=<class 'NoneType'>,version=1,metadata=None,host=127.0.0.1)
+
+```
+
+
 
 
 

--- a/docs/versionstore.md
+++ b/docs/versionstore.md
@@ -36,6 +36,8 @@ At this point you have an empty VersionStore library. You do not need to specify
                                                  (dt(2016, 1, 3), 1)],
                                                 names=['date', 'id']))
 >>> lib.write('test', df)
+VersionedItem(symbol=test,library=arctic.vstore,data=<class 'NoneType'>,version=1,metadata=None,host=127.0.0.1)
+
 >>> lib.read('test').data
                data
 date       id      
@@ -51,6 +53,8 @@ date       id
                                                names=['date', 'id']))
 
 >>> lib.write('test', df)
+VersionedItem(symbol=test,library=arctic.vstore,data=<class 'NoneType'>,version=2,metadata=None,host=127.0.0.1)
+
 >>> lib.read('test').data
                data
 date       id      
@@ -64,7 +68,7 @@ date       id
 
 * symbol
 * library
-* version
-* metadata
-* data
+* version - version number of the data written
+* metadata - metadata if exists, or None
+* data (for writes this is None, for reads it contains the data read from the database).
 * host

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,6 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Cython",
         "Operating System :: POSIX",
         "Operating System :: MacOS",
         "Operating System :: Microsoft :: Windows",


### PR DESCRIPTION
Create initial first pass of version store documentation. I've tried to cover the most important use cases for the main methods of version store, focusing on the basic usecase (dataframes). Is surely not complete, but I think its much better than what we currently have (nothing) :)


I will squash the commits into a single commit