### PR TITLE
Make host optional in VersionedItem (#619)

### DIFF
--- a/arctic/store/versioned_item.py
+++ b/arctic/store/versioned_item.py
@@ -5,6 +5,10 @@ class VersionedItem(namedtuple('VersionedItem', ['symbol', 'library', 'data', 'v
     """
     Class representing a Versioned object in VersionStore.
     """
+
+    def __new__(cls, symbol, library, data, version, metadata, host=None):
+        return super(VersionedItem, cls).__new__(cls, symbol, library, data, version, metadata, host)
+
     def metadata_dict(self):
         return {'symbol': self.symbol, 'library': self.library, 'version': self.version}
 

--- a/tests/unit/store/test_version_item.py
+++ b/tests/unit/store/test_version_item.py
@@ -17,6 +17,23 @@ def test_versioned_item_str():
     assert repr(item) == expected
 
 
+def test_versioned_item_default_host():
+    item = VersionedItem(symbol="sym",
+                         library="ONEMINUTE",
+                         data=[1, 2, 3],
+                         version=1.0,
+                         metadata={'metadata': 'foo'})
+
+    expected_item = VersionedItem(symbol="sym",
+                                  library="ONEMINUTE",
+                                  data=[1, 2, 3],
+                                  version=1.0,
+                                  host=None,
+                                  metadata={'metadata': 'foo'})
+
+    assert item == expected_item
+
+
 def test_versioned_item_str_handles_none():
     item = VersionedItem(symbol=None,
                          library=None,


### PR DESCRIPTION
This makes `VersionedItem` backwards compatible, so any third-party
libraries creating their own `VersionedItem`s won't be affected.