### PR TITLE
Fixed small bug in DateRange.intersection

### DIFF
--- a/arctic/date/_daterange.py
+++ b/arctic/date/_daterange.py
@@ -85,12 +85,12 @@ class DateRange(GeneralSlice):
                     else self.startopen if other.start is None \
                     else other.startopen if self.start < other.start \
                     else self.startopen if self.start > other.start \
-                    else (self.startopen and other.startopen)
+                    else (self.startopen or other.startopen)
         endopen = other.endopen if self.end is None \
                    else self.endopen if other.end is None \
                    else other.endopen if self.end > other.end \
                    else self.endopen if self.end < other.end \
-                   else (self.endopen and other.endopen)
+                   else (self.endopen or other.endopen)
 
         new_start = self.start if other.start is None \
                     else other.start if self.start is None \

--- a/tests/unit/date/test_daterange.py
+++ b/tests/unit/date/test_daterange.py
@@ -236,17 +236,12 @@ def test_intersection_preserves_boundaries():
 
 
 def test_intersection_contains():
-    # assert ((d in dr1) & (d in dr2)) == (d in (dr1 & dr2)) for any interval combination 
-    start, end = dt(2018,1,1), dt(2018,1,2)
+    # assert ((d in dr1) & (d in dr2)) == (d in (dr1 & dr2)) for any interval combination
+    start, end = dt(2018, 1, 1), dt(2018, 1, 2)
     date_ranges = [DateRange(start, end, interval) for interval in CLOSED_CLOSED.__class__]
-    
-    def equal_contains(date,dr1,dr2):
+
+    def equal_contains(date, dr1, dr2):
         return ((date in dr1) and (date in dr2)) == (date in dr1.intersection(dr2))
-   
-    assert all(equal_contains(start,dr1,dr2) for dr1 in date_ranges for dr2 in date_ranges)
-    assert all(equal_contains(end,dr1,dr2) for dr1 in date_ranges for dr2 in date_ranges)
-    
-   
-   
-   
-   
+
+    assert all(equal_contains(start, dr1, dr2) for dr1 in date_ranges for dr2 in date_ranges)
+    assert all(equal_contains(end, dr1, dr2) for dr1 in date_ranges for dr2 in date_ranges)

--- a/tests/unit/date/test_daterange.py
+++ b/tests/unit/date/test_daterange.py
@@ -234,3 +234,19 @@ def test_intersection_preserves_boundaries():
     assert DateRange('20110101', '20110102', OPEN_OPEN) == DateRange('20110101', '20110102', CLOSED_OPEN).intersection(DateRange('20110101', '20110102', OPEN_OPEN))
     assert DateRange('20110101', '20110102', OPEN_OPEN) == DateRange('20110101', '20110102', OPEN_OPEN).intersection(DateRange('20110101', '20110102', OPEN_CLOSED))
 
+
+def test_intersection_contains():
+    # assert ((d in dr1) & (d in dr2)) == (d in (dr1 & dr2)) for any interval combination 
+    start, end = dt(2018,1,1), dt(2018,1,2)
+    date_ranges = [DateRange(start, end, interval) for interval in CLOSED_CLOSED.__class__]
+    
+    def equal_contains(date,dr1,dr2):
+        return ((date in dr1) and (date in dr2)) == (date in dr1.intersection(dr2))
+   
+    assert all(equal_contains(start,dr1,dr2) for dr1 in date_ranges for dr2 in date_ranges)
+    assert all(equal_contains(end,dr1,dr2) for dr1 in date_ranges for dr2 in date_ranges)
+    
+   
+   
+   
+   


### PR DESCRIPTION
'DateRange.intersection' method returns CLOSED interval when intersecting ranges with same start[,end] and distinct interval values. 
It should return an  OPEN_*(>start) interval as it is subset of the same CLOSED_*(>=start)





 
