### PR TITLE
test datetimes: compare epoch instead of timestamps

### DIFF
--- a/tests/unit/date/test_util.py
+++ b/tests/unit/date/test_util.py
@@ -16,11 +16,21 @@ from arctic.date._util import to_dt, utc_dt_to_local_dt
                             dt(1990, 4, 5, 0, 0, tzinfo=mktz('EST')),
                             ]
 )
-def test_datetime_to_ms_and_back(pdt):
+@pytest.mark.parametrize('local_tz', [
+    mktz('EST'),
+    mktz('CET'),
+    mktz('Asia/Tokyo'),
+    mktz('Cuba'),
+    mktz('US/Alaska'),
+    mktz(),
+    mktz('Europe/London'),
+]
+)
+def test_datetime_to_ms_and_back(pdt, local_tz):
     i = datetime_to_ms(pdt)
-    pdt = pdt.astimezone(mktz())
-    pdt2 = ms_to_datetime(i)
-    assert pdt == pdt2
+    pdt = pdt.astimezone(local_tz)
+    pdt2 = ms_to_datetime(i, tzinfo=local_tz)
+    assert datetime_to_ms(pdt) == datetime_to_ms(pdt2)
 
 
 def test_datetime_to_ms_and_back_microseconds():


### PR DESCRIPTION
Comparing datatime.datetime objects with timezones different from UTC can held different behaviours if we are at the boundaries of a daylight saving time change. E.g. This code 
```
    d1 = dt(2007, 3, 25, 0, tzinfo=mktz('Europe/London'))
    d2 = dt(2007, 3, 25, 1, tzinfo=mktz('Europe/London'))

    print datetime_to_ms(d1) == datetime_to_ms(d2)
    print d1 == d2
```
prints
```
True
False
```
For this reason, the test `test_datetime_to_ms_and_back()` fails depending on which timezone the machine is running from.

Reccomendation from [pytz](http://pytz.sourceforge.net/) are:

> The preferred way of dealing with times is to always work in UTC, converting to localtime only when generating output to be read by humans.