### PR TITLE
Complete implementation and tests for the fast is-serializable check

### DIFF
--- a/benchmarks/fast_serializable_check.py
+++ b/benchmarks/fast_serializable_check.py
@@ -1,0 +1,46 @@
+import time
+
+import arctic.serialization.numpy_records as anr
+from tests.unit.serialization.serialization_test_data import _mixed_test_data as input_test_data
+
+df_serializer = anr.DataFrameSerializer()
+
+
+def _bench(rounds, input_df, fast):
+    fast = bool(fast)
+    anr.set_fast_check_df_serializable(fast)
+    start = time.time()
+    for i in range(rounds):
+        df_serializer.can_convert_to_records_without_objects(input_df, 'symA')
+    print("Time per iteration (fast={}): {}".format(fast, (time.time() - start)/rounds))
+
+
+# Results suggest significant speed improvements for
+#   (1) large df with objects
+#       Time per iteration (fast=False): 0.0281402397156
+#       Time per iteration (fast=True):  0.00866063833237
+#   (2) large multi-column df
+#       Time per iteration (fast=False): 0.00556221961975
+#       Time per iteration (fast=True):  0.00276621818542
+#   (3) large multi-index df
+#       Time per iteration (fast=False): 0.00640722036362
+#       Time per iteration (fast=True):  0.00154552936554
+def assess_speed(df_kind):
+    rounds = 100
+    input_df = input_test_data()[df_kind][0]
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        _bench(rounds, input_df, fast=False)
+
+        _bench(rounds, input_df, fast=True)
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config
+
+
+def main():
+    for df_kind in ('large_with_some_objects', 'large_multi_index', 'large_multi_column'):
+        assess_speed(df_kind)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -15,28 +15,7 @@ import pickle
 
 from arctic.chunkstore.chunkstore import START, SYMBOL
 from arctic.chunkstore.passthrough_chunker import PassthroughChunker
-
-
-def create_test_data(size=5, index=True, multiindex=True, random_data=True, random_ids=True, date_offset=0, cols=1):
-    data = {}
-    for i in range(cols):
-        if random_data:
-            data['data' + str(i)] = [random.random() * random.randint(-100, 100) for _ in range(size)]
-        else:
-            data['data' + str(i)] = range(size)
-    dates = [dt(2016, 1, 1) + timedelta(days=n+date_offset) for n in range(size)]
-    if index:
-        if multiindex:
-            if random_ids:
-                idx = [(date, random.randint(1, size)) for date in dates]
-            else:
-                idx = [(date, 1) for date in dates]
-            index = MultiIndex.from_tuples(idx, names=['date', 'id'])
-            return DataFrame(data=data, index=index)
-        return DataFrame(data=data, index=Index(data=dates, name='date'))
-    data.update({'date': dates})
-    return DataFrame(data=data)
-
+from tests.integration.chunkstore.test_utils import create_test_data
 
 def test_write_dataframe(chunkstore_lib):
     df = create_test_data()

--- a/tests/integration/chunkstore/test_utils.py
+++ b/tests/integration/chunkstore/test_utils.py
@@ -2,28 +2,26 @@ import random
 from datetime import datetime as dt
 from datetime import timedelta
 
-import pandas as pd
 from pandas import DataFrame, Index, MultiIndex
 from pandas.util.testing import assert_frame_equal
 
 from arctic.chunkstore.utils import read_apply
 
 
-def create_test_data(size=5, index=True, multiindex=True, random_data=True, random_ids=True, date_offset=0, cols=1):
+def create_test_data(size=5, index=True, multiindex=True, random_data=True, random_ids=True, date_offset=0, use_hours=False, cols=1):
     data = {}
     for i in range(cols):
         if random_data:
             data['data' + str(i)] = [random.random() * random.randint(-100, 100) for _ in range(size)]
         else:
             data['data' + str(i)] = range(size)
-    dates = [dt(2016, 1, 1) + timedelta(days=n+date_offset) for n in range(size)]
+    dates = [dt(2016, 1, 1) + timedelta(days=0 if use_hours else n+date_offset,
+                                        hours=n+date_offset if use_hours else 0) for n in range(size)]
     if index:
         if multiindex:
-            if random_ids:
-                idx = [(date, random.randint(1, size)) for date in dates]
-            else:
-                idx = [(date, 1) for date in dates]
-            index = MultiIndex.from_tuples(idx, names=['date', 'id'])
+            index_col_names = ['date', 'id']
+            idx = [(date, random.randint(1, size)) for date in dates] if random_ids else [(date, 1) for date in dates]
+            index = MultiIndex.from_tuples(idx, names=index_col_names) if idx else MultiIndex([[]]*2, [[]]*2, names=index_col_names)
             return DataFrame(data=data, index=index)
         return DataFrame(data=data, index=Index(data=dates, name='date'))
     data.update({'date': dates})

--- a/tests/integration/test_compress_integration.py
+++ b/tests/integration/test_compress_integration.py
@@ -70,4 +70,3 @@ def test_exceptions():
     with pytest.raises(Exception) as e:
         c.decompress_array(data)
     assert ("decompressor wrote" in str(e).lower() or "corrupt input at" in str(e).lower() or "decompression failed: corrupt input" in str(e).lower())
-

--- a/tests/unit/serialization/serialization_test_data.py
+++ b/tests/unit/serialization/serialization_test_data.py
@@ -1,0 +1,120 @@
+import numpy as np
+import pandas as pd
+
+from arctic.serialization.numpy_records import DataFrameSerializer
+from tests.integration.chunkstore.test_utils import create_test_data
+
+from tests.util import get_large_ts
+
+NON_HOMOGENEOUS_DTYPE_PATCH_SIZE_ROWS = 50
+_TEST_DATA = None
+
+df_serializer = DataFrameSerializer()
+
+
+def _mixed_test_data():
+    global _TEST_DATA
+    if _TEST_DATA is None:
+        onerow_ts = get_large_ts(1)
+        small_ts = get_large_ts(10)
+        medium_ts = get_large_ts(600)
+        large_ts = get_large_ts(1800)
+        empty_ts = pd.DataFrame()
+        empty_index = create_test_data(size=0, cols=10, index=True, multiindex=False, random_data=True, random_ids=True)
+
+        with_some_objects_ts = medium_ts.copy(deep=True)
+        with_some_objects_ts.iloc[0:NON_HOMOGENEOUS_DTYPE_PATCH_SIZE_ROWS, 0] = None
+        with_some_objects_ts.iloc[0:NON_HOMOGENEOUS_DTYPE_PATCH_SIZE_ROWS, 1] = 'A string'
+        large_with_some_objects = create_test_data(size=10000, cols=64, index=True, multiindex=False, random_data=True,
+                                                   random_ids=True, use_hours=True)
+        large_with_some_objects.iloc[0:NON_HOMOGENEOUS_DTYPE_PATCH_SIZE_ROWS, 0] = None
+        large_with_some_objects.iloc[0:NON_HOMOGENEOUS_DTYPE_PATCH_SIZE_ROWS, 1] = 'A string'
+
+        with_string_ts = medium_ts.copy(deep=True)
+        with_string_ts['str_col'] = 'abc'
+        with_unicode_ts = medium_ts.copy(deep=True)
+        with_unicode_ts['ustr_col'] = u'abc'
+
+        with_some_none_ts = medium_ts.copy(deep=True)
+        with_some_none_ts.iloc[10:10] = None
+        with_some_none_ts.iloc[-10:-10] = np.nan
+        with_some_none_ts = with_some_none_ts.replace({np.nan: None})
+
+        # Multi-index data frames
+        multiindex_ts = create_test_data(size=500, cols=10, index=True, multiindex=True, random_data=True,
+                                         random_ids=True)
+        empty_multiindex_ts = create_test_data(size=0, cols=10, index=True, multiindex=True, random_data=True,
+                                               random_ids=True)
+        large_multi_index = create_test_data(
+            size=50000, cols=10, index=True, multiindex=True, random_data=True, random_ids=True, use_hours=True)
+
+        # Multi-column data frames
+        columns = pd.MultiIndex.from_product([["bar", "baz", "foo", "qux"], ["one", "two"]], names=["first", "second"])
+        empty_multi_column_ts = pd.DataFrame([], columns=columns)
+
+        columns = pd.MultiIndex.from_product([["bar", "baz", "foo", "qux"], ["one", "two"]], names=["first", "second"])
+        multi_column_no_multiindex = pd.DataFrame(np.random.randn(2, 8), index=[0, 1], columns=columns)
+
+        large_multi_column = pd.DataFrame(np.random.randn(100000, 8), index=range(100000), columns=columns)
+
+        columns = pd.MultiIndex.from_product([[1, 2, 'a'], ['c', 5]])
+        multi_column_int_levels = pd.DataFrame([[9, 2, 8, 1, 2, 3], [3, 4, 2, 9, 10, 11]],
+                                               index=['x', 'y'], columns=columns)
+
+        # Multi-index and multi-column data frames
+        columns = pd.MultiIndex.from_product([["bar", "baz", "foo", "qux"], ["one", "two"]])
+        index = pd.MultiIndex.from_product([["x", "y", "z"], ["a", "b"]])
+        multi_column_and_multi_index = pd.DataFrame(np.random.randn(6, 8), index=index, columns=columns)
+
+        # Nested n-dimensional
+        def _new_np_nd_array(val):
+            return np.rec.array([(val, ['A', 'BC'])],
+                                dtype=[('index', '<M8[ns]'), ('values', 'S2', (2,))])
+        n_dimensional_df = pd.DataFrame(
+            {'a': [_new_np_nd_array(1356998400000000000), _new_np_nd_array(1356998400000000001)],
+             'b': [_new_np_nd_array(1356998400000000002), _new_np_nd_array(1356998400000000003)]
+             },
+            index=(0, 1))
+
+        # Exhaust all dtypes
+        mixed_dtypes_df = pd.DataFrame({
+            'string': list('abc'),
+            'int64': list(range(1, 4)),
+            'uint8': np.arange(3, 6).astype('u1'),
+            'uint64': np.arange(3, 6).astype('u8'),
+            'float64': np.arange(4.0, 7.0),
+            'bool1': [True, False, True],
+            'dates': pd.date_range('now', periods=3).values,
+            'other_dates': pd.date_range('20130101', periods=3).values,
+            # 'category': pd.Series(list("ABC")).astype('category'),
+            'tz_aware_dates': pd.date_range('20130101', periods=3, tz='US/Eastern'),
+            'complex': np.array([1. + 4.j, 2. + 5.j, 3. + 6.j])
+        })
+        mixed_dtypes_df['timedeltas'] = mixed_dtypes_df.dates.diff()
+
+        _TEST_DATA = {
+            'onerow': (onerow_ts, df_serializer.serialize(onerow_ts)),
+            'small': (small_ts, df_serializer.serialize(small_ts)),
+            'medium': (medium_ts, df_serializer.serialize(medium_ts)),
+            'large': (large_ts, df_serializer.serialize(large_ts)),
+            'empty': (empty_ts, df_serializer.serialize(empty_ts)),
+            'empty_index': (empty_index, df_serializer.serialize(empty_index)),
+            'with_some_objects': (with_some_objects_ts, df_serializer.serialize(with_some_objects_ts)),
+            'large_with_some_objects': (large_with_some_objects, df_serializer.serialize(large_with_some_objects)),
+            'with_string': (with_string_ts, df_serializer.serialize(with_string_ts)),
+            'with_unicode': (with_unicode_ts, df_serializer.serialize(with_unicode_ts)),
+            'with_some_none': (with_some_none_ts, df_serializer.serialize(with_some_none_ts)),
+            'multiindex': (multiindex_ts, df_serializer.serialize(multiindex_ts)),
+            'empty_multiindex': (empty_multiindex_ts, df_serializer.serialize(empty_multiindex_ts)),
+            'large_multi_index': (large_multi_index, df_serializer.serialize(large_multi_index)),
+            'empty_multicolumn': (empty_multi_column_ts, df_serializer.serialize(empty_multi_column_ts)),
+            'multi_column_no_multiindex': (multi_column_no_multiindex,
+                                           df_serializer.serialize(multi_column_no_multiindex)),
+            'large_multi_column': (large_multi_column, df_serializer.serialize(large_multi_column)),
+            'multi_column_int_levels': (multi_column_int_levels, df_serializer.serialize(multi_column_int_levels)),
+            'multi_column_and_multi_index': (multi_column_and_multi_index,
+                                             df_serializer.serialize(multi_column_and_multi_index)),
+            'n_dimensional_df': (n_dimensional_df, Exception),
+            'mixed_dtypes_df': (mixed_dtypes_df, df_serializer.serialize(mixed_dtypes_df))
+        }
+    return _TEST_DATA

--- a/tests/unit/serialization/test_numpy_records.py
+++ b/tests/unit/serialization/test_numpy_records.py
@@ -1,57 +1,102 @@
 import numpy as np
-
-from numpy.testing import assert_array_equal
+import pytest
 from mock import patch, Mock, sentinel
-from arctic.serialization.numpy_records import PandasSerializer, _to_primitive
+from numpy.testing import assert_array_equal
 from pandas import Timestamp
+
+import arctic.serialization.numpy_records as anr
 
 
 def test_to_primitive_timestamps():
-    arr = _to_primitive(np.array([Timestamp('2010-11-12 00:00:00')]))
+    arr = anr._to_primitive(np.array([Timestamp('2010-11-12 00:00:00')]))
     assert_array_equal(arr, np.array([Timestamp('2010-11-12 00:00:00').value], dtype='datetime64[ns]'))
 
-def test_can_convert_to_records_without_objects_returns_false_on_exception_in_to_records():
-    store = PandasSerializer()
-    store._to_records = Mock(side_effect=TypeError('uhoh'))
 
-    with patch('arctic.serialization.numpy_records.log') as mock_log:
-        assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
+@pytest.mark.parametrize("fast_serializable_check", (True, False))
+def test_can_convert_to_records_without_objects_returns_false_on_exception_in_to_records(fast_serializable_check):
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        anr.set_fast_check_df_serializable(fast_serializable_check)
+        store = anr.PandasSerializer()
+        mymock = Mock(side_effect=TypeError('uhoh'))
+        if fast_serializable_check:
+            store.fast_check_serializable = mymock
+        else:
+            store._to_records = mymock
+        with patch('arctic.serialization.numpy_records.log') as mock_log:
+            assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
 
-    mock_log.info.assert_called_once_with('Pandas dataframe my_symbol caused exception "TypeError(\'uhoh\',)"'
-                                          ' when attempting to convert to records. Saving as Blob.')
-    store._to_records.assert_called_once_with(sentinel.df)
-
-
-def test_can_convert_to_records_without_objects_returns_false_when_records_have_object_dtype():
-    store = PandasSerializer()
-    store._to_records = Mock(return_value=(np.array(['a', 'b', None, 'd']), None))
-
-    with patch('arctic.serialization.numpy_records.log') as mock_log:
-        assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
-
-    mock_log.warning.assert_called_once_with('Pandas dataframe my_symbol contains Objects, saving as Blob')
-    store._to_records.assert_called_once_with(sentinel.df)
-
-
-def test_can_convert_to_records_without_objects_returns_false_when_records_have_arrays_in_them():
-    store = PandasSerializer()
-    store._to_records = Mock(return_value=(np.rec.array([(1356998400000000000, ['A', 'BC'])],
-                                                       dtype=[('index', '<M8[ns]'), ('values', 'S2', (2,))]), None))
-
-    with patch('arctic.serialization.numpy_records.log') as mock_log:
-        assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
-
-    mock_log.info.assert_called_once_with('Pandas dataframe my_symbol contains >1 dimensional arrays, saving as Blob')
-    store._to_records.assert_called_once_with(sentinel.df)
+        mock_log.warning.assert_called_once_with('Pandas dataframe my_symbol caused exception "TypeError(\'uhoh\',)" '
+                                                 'when attempting to convert to records. Saving as Blob.')
+        if fast_serializable_check:
+            store.fast_check_serializable.assert_called_once_with(sentinel.df)
+        else:
+            store._to_records.assert_called_once_with(sentinel.df)
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config
 
 
-def test_can_convert_to_records_without_objects_returns_true_otherwise():
-    store = PandasSerializer()
-    store._to_records = Mock(return_value=(np.rec.array([(1356998400000000000, 'a')],
-                                                       dtype=[('index', '<M8[ns]'), ('values', 'S2')]), None))
+@pytest.mark.parametrize("fast_serializable_check", (True, False))
+def test_can_convert_to_records_without_objects_returns_false_when_records_have_object_dtype(fast_serializable_check):
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        anr.set_fast_check_df_serializable(fast_serializable_check)
+        store = anr.PandasSerializer()
+        mymock = Mock(return_value=(np.array(['a', 'b', None, 'd']), None))
+        if fast_serializable_check:
+            store.fast_check_serializable = mymock
+        else:
+            store._to_records = mymock
+        with patch('arctic.serialization.numpy_records.log') as mock_log:
+            assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
+        mock_log.warning.assert_called_once_with('Pandas dataframe my_symbol contains Objects, saving as Blob')
+        if fast_serializable_check:
+            store.fast_check_serializable.assert_called_once_with(sentinel.df)
+        else:
+            store._to_records.assert_called_once_with(sentinel.df)
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config
 
-    with patch('arctic.serialization.numpy_records.log') as mock_log:
-        assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is True
 
-    assert mock_log.info.call_count == 0
-    store._to_records.assert_called_once_with(sentinel.df)
+@pytest.mark.parametrize("fast_serializable_check", (True, False))
+def test_can_convert_to_records_without_objects_returns_false_when_records_have_arrays_in_them(fast_serializable_check):
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        anr.set_fast_check_df_serializable(fast_serializable_check)
+        store = anr.PandasSerializer()
+        mymock = Mock(return_value=(np.rec.array([(1356998400000000000, ['A', 'BC'])], dtype=[('index', '<M8[ns]'), ('values', 'S2', (2,))]), None))
+        if fast_serializable_check:
+            store.fast_check_serializable = mymock
+        else:
+            store._to_records = mymock
+        with patch('arctic.serialization.numpy_records.log') as mock_log:
+            assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is False
+        mock_log.warning.assert_called_once_with('Pandas dataframe my_symbol contains >1 dimensional arrays, saving as Blob')
+        if fast_serializable_check:
+            store.fast_check_serializable.assert_called_once_with(sentinel.df)
+        else:
+            store._to_records.assert_called_once_with(sentinel.df)
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config
+
+
+@pytest.mark.parametrize("fast_serializable_check", (True, False))
+def test_can_convert_to_records_without_objects_returns_true_otherwise(fast_serializable_check):
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        anr.set_fast_check_df_serializable(fast_serializable_check)
+        store = anr.PandasSerializer()
+        mymock = Mock(return_value=(np.rec.array([(1356998400000000000, 'a')], dtype=[('index', '<M8[ns]'), ('values', 'S2')]), None))
+        if fast_serializable_check:
+            store.fast_check_serializable = mymock
+        else:
+            store._to_records = mymock
+        with patch('arctic.serialization.numpy_records.log') as mock_log:
+            assert store.can_convert_to_records_without_objects(sentinel.df, 'my_symbol') is True
+        assert mock_log.warning.call_count == 0
+        if fast_serializable_check:
+            store.fast_check_serializable.assert_called_once_with(sentinel.df)
+        else:
+            store._to_records.assert_called_once_with(sentinel.df)
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config

--- a/tests/unit/serialization/test_pandas_is_serializable.py
+++ b/tests/unit/serialization/test_pandas_is_serializable.py
@@ -1,0 +1,20 @@
+import pytest
+
+import arctic.serialization.numpy_records as anr
+from tests.unit.serialization.serialization_test_data import _mixed_test_data as input_test_data
+
+df_serializer = anr.DataFrameSerializer()
+
+
+@pytest.mark.parametrize("input_df", input_test_data().keys())
+def test_dataframe_confirm_fast_check_compatibility(input_df):
+    orig_config = anr._FAST_CHECK_DF_SERIALIZABLE
+    try:
+        input_df = input_test_data()[input_df][0]
+        anr.set_fast_check_df_serializable(True)
+        with_fast_check = df_serializer.can_convert_to_records_without_objects(input_df, 'symA')
+        anr.set_fast_check_df_serializable(False)
+        without_fast_check = df_serializer.can_convert_to_records_without_objects(input_df, 'symA')
+        assert with_fast_check == without_fast_check
+    finally:
+        anr._FAST_CHECK_DF_SERIALIZABLE = orig_config


### PR DESCRIPTION
Issue #590

I extracted only the fast check improvement form the incremental serialization branch.

This has already been reviewed/approved:
https://github.com/dimosped/arctic/pull/1

It is turned off by default, and I'd like to include it in the next release
