### PR TITLE
[EXPERIMENTAL] Initial implementation of the public arctic async api (Python 2 and 3)

### DIFF
--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -85,3 +85,10 @@ LZ4_MINSZ_PARALLEL = os.environ.get('LZ4_MINSZ_PARALLEL', 0.5*1024**2)  # 0.5 MB
 
 # Enable this when you run the benchmark_lz4.py
 BENCHMARK_MODE = False
+
+
+# ---------------------------
+# Async arctic
+# ---------------------------
+# Configures the size of the workers pools used for async arctic requests
+ARCTIC_ASYNC_NWORKERS = os.environ.get('ARCTIC_ASYNC_NWORKERS', 4)

--- a/arctic/async/__init__.py
+++ b/arctic/async/__init__.py
@@ -1,0 +1,2 @@
+from .async_arctic import ASYNC_ARCTIC, async_arctic_submit, async_wait_request, async_wait_requests, async_join_all, \
+    async_reset_pool, async_total_requests

--- a/arctic/async/__init__.py
+++ b/arctic/async/__init__.py
@@ -1,2 +1,3 @@
-from .async_arctic import ASYNC_ARCTIC, async_arctic_submit, async_wait_request, async_wait_requests, async_join_all, \
+from .async_arctic import ASYNC_ARCTIC, async_arctic_submit, \
+    async_wait_request, async_wait_requests, async_shutdown, async_await_termination, \
     async_reset_pool, async_total_requests

--- a/arctic/async/_workers_pool.py
+++ b/arctic/async/_workers_pool.py
@@ -156,6 +156,8 @@ class LazySingletonTasksCoordinator(ABC):
         return total
 
     def shutdown(self, timeout=None):
+        if self.is_shutdown:
+            return
         with type(self)._POOL_LOCK:
             self.is_shutdown = True
         if timeout is not None:

--- a/arctic/async/_workers_pool.py
+++ b/arctic/async/_workers_pool.py
@@ -1,0 +1,168 @@
+import abc
+import logging
+import uuid
+
+from concurrent.futures import ThreadPoolExecutor, wait, ALL_COMPLETED, FIRST_EXCEPTION
+from six import iteritems, itervalues
+from threading import RLock, Event
+
+from arctic._config import ARCTIC_ASYNC_NWORKERS
+from arctic.exceptions import AsyncArcticException
+
+ABC = abc.ABCMeta('ABC', (object,), {})
+
+
+def _looping_task(shutdown_flag, fun, *args, **kwargs):
+    while not shutdown_flag.is_set():
+        try:
+            fun(*args, **kwargs)
+        except Exception as e:
+            logging.exception("Task failed {}".format(fun))
+            raise e
+
+
+def _exec_task(fun, *args, **kwargs):
+    try:
+        fun(*args, **kwargs)
+    except Exception as e:
+        logging.exception("Task failed {}".format(fun))
+        raise e
+
+
+class LazySingletonWorkersPool(ABC):
+    """
+    A Thread-Safe singleton lazily initialized thread pool class (encapsulating concurrent.futures.ThreadPoolExecutor)
+    """
+    _instance = None
+    _SINGLETON_LOCK = RLock()
+    _POOL_LOCK = RLock()
+
+    @classmethod
+    def is_initialized(cls):
+        with cls._POOL_LOCK:
+            is_init = cls._instance is not None and cls._instance._pool is not None
+        return is_init
+
+    @classmethod
+    def get_instance(cls, pool_size=None):
+        if cls._instance is not None:
+            return cls._instance
+
+        # Lazy init
+        with cls._SINGLETON_LOCK:
+            if cls._instance is None:
+                cls._instance = cls(ARCTIC_ASYNC_NWORKERS if pool_size is None else pool_size)
+        return cls._instance
+
+    @property
+    def _workers_pool(self):
+        if self._pool is not None:
+            return self._pool
+
+        # lazy init the workers pool
+        got_initialized = False
+        with type(self)._POOL_LOCK:
+            if self._pool is None:
+                self._pool = ThreadPoolExecutor(max_workers=self._pool_size,
+                                                thread_name_prefix='AsyncArcticWorker')
+                got_initialized = True
+
+        # Call hooks outside the lock, to minimize time-under-lock
+        if got_initialized:
+            for hook in self._pool_update_hooks:
+                hook(self._pool_size)
+
+        return self._pool
+
+    def __init__(self, pool_size):
+        # Only allow creation via get_instance
+        if not type(self)._SINGLETON_LOCK._is_owned():
+            raise AsyncArcticException("{} is a singleton, can't create a new instance".format(type(self)))
+
+        pool_size = int(pool_size)
+        if pool_size < 1:
+            raise ValueError("{} can't be instantiated with a pool_size of {}".format(type(self), pool_size))
+
+        # Enforce the singleton pattern
+        with type(self)._SINGLETON_LOCK:
+            if type(self)._instance is not None:
+                raise AsyncArcticException("LazySingletonWorkersPool is a singleton, can't create a new instance")
+            self._lock = RLock()
+            self._pool = None
+            self._pool_size = int(pool_size)
+            self._pool_update_hooks = []
+            self.alive_tasks = {}
+
+    def reset(self, block=True, pool_size=None, timeout=None):
+        pool_size = ARCTIC_ASYNC_NWORKERS if pool_size is None else int(pool_size)
+        with type(self)._POOL_LOCK:
+            self.stop_all_running_tasks()
+            self.wait_all_running_tasks(timeout=timeout)
+            self._workers_pool.shutdown(wait=block)
+            pool_size = max(pool_size, 1)
+            self._pool = None
+            self._pool_size = pool_size
+            # pool will be lazily initialized with pool_size on next request submission
+
+    def stop_all_running_tasks(self):
+        with type(self)._POOL_LOCK:
+            for fut, ev in (v for v in itervalues(self.alive_tasks) if not v[0].done()):
+                if ev:
+                    ev.set()
+                fut.cancel()
+
+    def wait_all_running_tasks(self, timeout=None, return_when=ALL_COMPLETED, raise_exceptions=True):
+        with type(self)._POOL_LOCK:
+            LazySingletonWorkersPool.wait_tasks(
+                [v[0] for v in itervalues(self.alive_tasks)],
+                timeout=timeout, return_when=return_when, raise_exceptions=raise_exceptions)
+        self.alive_tasks = {}
+
+    @staticmethod
+    def wait_tasks(futures, timeout=None, return_when=ALL_COMPLETED, raise_exceptions=True):
+        running_futures = [fut for fut in futures if not fut.done()]
+        done, _ = wait(running_futures, timeout=timeout, return_when=return_when)
+        if raise_exceptions:
+            [f.result() for f in done if not f.cancelled() and f.exception() is not None]  # raises the exception
+
+    @staticmethod
+    def wait_tasks_or_abort(futures, timeout=60, kill_switch_ev=None):
+        try:
+            LazySingletonWorkersPool.wait_tasks(futures, return_when=FIRST_EXCEPTION, raise_exceptions=True)
+        except Exception as e:
+            if kill_switch_ev is not None:
+                # Used when we want to keep both raise the exception and wait for all tasks to finish
+                kill_switch_ev.set()
+                LazySingletonWorkersPool.wait_tasks(futures, return_when=ALL_COMPLETED,
+                                                    raise_exceptions=False, timeout=timeout)
+            raise e
+
+    def register_update_hook(self, fun):
+        with type(self)._POOL_LOCK:
+            self._pool_update_hooks.append(fun)
+
+    def submit_task(self, is_looping, fun, *args, **kwargs):
+        new_id = uuid.uuid4()
+        shutdown_flag = Event() if is_looping else None
+        with type(self)._POOL_LOCK:
+            if is_looping:
+                new_future = self._workers_pool.submit(_looping_task, shutdown_flag, fun, *args, **kwargs)
+            else:
+                new_future = self._workers_pool.submit(_exec_task, fun, *args, **kwargs)
+            self.alive_tasks = {k: v for k, v in iteritems(self.alive_tasks) if not v[0].done()}
+            self.alive_tasks[new_id] = (new_future, shutdown_flag)
+        return new_id, new_future
+
+    def total_alive_tasks(self):
+        with type(self)._POOL_LOCK:
+            self.alive_tasks = {k: v for k, v in iteritems(self.alive_tasks) if not v[0].done()}
+            total = len(self.alive_tasks)
+        return total
+
+    @property
+    def actual_pool_size(self):
+        return self._workers_pool._max_workers
+
+    @abc.abstractmethod
+    def __reduce__(self):
+        pass

--- a/arctic/async/async_arctic.py
+++ b/arctic/async/async_arctic.py
@@ -1,0 +1,187 @@
+import logging
+import time
+from collections import defaultdict
+from threading import RLock
+
+from concurrent.futures import FIRST_COMPLETED
+
+from .async_utils import AsyncRequestType, AsyncRequest
+from ._workers_pool import LazySingletonWorkersPool
+from ..decorators import mongo_retry
+from ..exceptions import AsyncArcticException
+
+
+def _arctic_task_exec(request):
+    request.start_time = time.time()
+    logging.debug("Executing asynchronous request for {}/{}".format(request.library, request.symbol))
+    result = None
+    try:
+        request.is_running = True
+        if request.mongo_retry:
+            result = mongo_retry(request.fun)(*request.args, **request.kwargs)
+        else:
+            result = request.fun(*request.args, **request.kwargs)
+    except Exception as e:
+        request.exception = e
+    finally:
+        request.data = result
+        request.end_time = time.time()
+        request.is_running = False
+    return result
+
+
+class AsyncArctic(LazySingletonWorkersPool):
+    _instance = None
+    _SINGLETON_LOCK = RLock()
+    _POOL_LOCK = RLock()
+
+    def __init__(self, pool_size):
+        # Only allow creation via get_instance
+        if not type(self)._SINGLETON_LOCK._is_owned():
+            raise AsyncArcticException("AsyncArctic is a singleton, can't create a new instance")
+
+        # Enforce the singleton pattern
+        with type(self)._SINGLETON_LOCK:
+            super(AsyncArctic, self).__init__(pool_size)
+            self.requests_per_library = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
+            self.requests_by_id = dict()
+
+    def __reduce__(self):
+        return "ASYNC_ARCTIC"
+
+    def _get_modifiers(self, library_name, symbol=None):
+        return self.requests_per_library[library_name][symbol][AsyncRequestType.MODIFIER]
+
+    def _get_accessors(self, library_name, symbol=None):
+        return self.requests_per_library[library_name][symbol][AsyncRequestType.ACCESSOR]
+
+    @staticmethod
+    def _verify_request(store, is_modifier, **kwargs):
+        library_name = None if store is None else store._arctic_lib.get_name()
+        symbol = kwargs.get('symbol')
+        kind = AsyncRequestType.MODIFIER if is_modifier else AsyncRequestType.ACCESSOR
+        callback = kwargs.get('async_callback')
+        mongo_retry = bool(kwargs.get('mongo_retry'))
+        return library_name, symbol, kind, callback, mongo_retry
+
+    def _add_request(self, request):
+        self.requests_per_library[request.library][request.symbol][request.kind].append(request)
+        self.requests_by_id[request.id] = request
+
+    def _remove_request(self, request):
+        self.requests_per_library[request.library][request.symbol][request.kind].remove(request)
+        if request.id in self.requests_by_id:
+            del self.requests_by_id[request.id]
+
+    def submit_arctic_request(self, store, fun, is_modifier, *args, **kwargs):
+        lib_name, symbol, kind, callback, mongo_retry = AsyncArctic._verify_request(store, is_modifier, **kwargs)
+
+        for k in ('async_callback', 'mongo_retry'):
+            kwargs.pop(k, None)
+
+        with type(self)._POOL_LOCK:  # class level lock, since it is a Singleton
+            if lib_name:
+                if self._get_modifiers(lib_name, symbol):
+                    raise AsyncArcticException("Can't submit async task as one or more {} tasks "
+                                               "are already being processed".format(AsyncRequestType.MODIFIER))
+
+                if is_modifier and self._get_accessors(lib_name, symbol):
+                    raise AsyncArcticException("Can't submit async {} task as one or more {} tasks "
+                                               "are being processed".format(AsyncRequestType.ACCESSOR,
+                                                                            AsyncRequestType.MODIFIER))
+
+            # Create the request object
+            request = AsyncRequest(kind, lib_name, fun, *args, **kwargs)
+
+            # Update the state of tracked tasks
+            self._add_request(request)
+
+            # Submit the task
+            try:
+                new_id, new_future = self.submit_task(False, _arctic_task_exec, request)
+                request.id = new_id
+                request.future = new_future
+            except Exception:
+                # clean up the state
+                self._remove_request(request)
+                raise
+
+        # No need to hold the lock for the below statements
+        # If request is already finished by now, the callback is invoked immediately
+        request.future.add_done_callback(lambda the_future: self._request_finished(request, callback))
+
+        return request
+
+    def _request_finished(self, request, callback=None):
+        with type(self)._POOL_LOCK:
+            self._remove_request(request)
+        request.is_completed = True
+        if callback:
+            callback(request)
+
+    @staticmethod
+    def wait_request(request, timeout=None):
+        while request is not None and not request.is_completed:
+            AsyncArctic.wait_tasks_or_abort((request.future, ), timeout=timeout)
+
+    @staticmethod
+    def wait_requests(requests, timeout=None):
+        while requests and not all(r.is_completed for r in requests):
+            AsyncArctic.wait_tasks_or_abort(tuple(r.future for r in requests if not r.is_completed), timeout=timeout)
+
+    @staticmethod
+    def wait_any_request(requests, timeout=None):
+        while requests and not any(r.is_completed for r in requests):
+            AsyncArctic.wait_tasks(tuple(r.future for r in requests if not r.is_completed),
+                                   timeout=timeout, return_when=FIRST_COMPLETED, raise_exceptions=True)
+
+    @staticmethod
+    def filter_finished_requests(requests, do_raise=True):
+        if not requests:
+            return requests, requests
+        alive_requests = [r for r in requests if not r.is_completed]
+        done_requests = [r for r in requests if r.is_completed]
+        if do_raise:
+            AsyncArctic.raise_errored(done_requests)
+        return alive_requests, done_requests
+
+    @staticmethod
+    def raise_errored(requests):
+        errored = tuple(r for r in requests if r.is_completed and r.exception is not None)
+        if errored:
+            raise errored[0].exception
+
+    def join(self, timeout=None):
+        while len(self.requests_by_id):
+            try:
+                AsyncArctic.wait_requests(self.requests_by_id.values(), timeout=timeout)
+            except Exception as e:
+                logging.exception("Failed to join all requests")
+
+    def total_requests(self):
+        return len(self.requests_by_id)
+
+
+ASYNC_ARCTIC = AsyncArctic.get_instance()
+async_arctic_submit = ASYNC_ARCTIC.submit_arctic_request
+async_wait_request = ASYNC_ARCTIC.wait_request
+async_wait_requests = ASYNC_ARCTIC.wait_requests
+async_join_all = ASYNC_ARCTIC.join
+async_reset_pool = ASYNC_ARCTIC.reset
+async_total_requests = ASYNC_ARCTIC.total_requests
+
+
+# def async_modifier(func):
+#     @wraps(func)
+#     def wrapper(self, *args, **kwargs):
+#         return async_arctic_submit(self, func, True, *args, **kwargs)
+#
+#     return wrapper
+#
+#
+# def async_accessor(func):
+#     @wraps(func)
+#     def wrapper(self, *args, **kwargs):
+#         return async_arctic_submit(self, func, False, *args, **kwargs)
+#
+#     return wrapper

--- a/arctic/async/async_utils.py
+++ b/arctic/async/async_utils.py
@@ -1,0 +1,64 @@
+import time
+import uuid
+from enum import Enum
+
+from arctic.exceptions import RequestDurationException
+
+
+class AsyncRequestType(Enum):
+    MODIFIER = 'modifier'
+    ACCESSOR = 'accessor'
+
+
+class AsyncRequest(object):
+    def __init__(self, kind, library, fun, *args, **kwargs):
+        self.id = uuid.uuid4()
+
+        # Request library call spec
+        self.fun = fun
+        self.args = args
+        self.kwargs = kwargs
+
+        # Request meta
+        self.kind = kind
+        self.library = library
+        self.symbol = kwargs.get('symbol')
+
+        # Request's state
+        self.future = None
+        self.data = None
+        self.exception = None
+        self.is_running = False
+        self.is_completed = False
+
+        # Timekeeping
+        self.start_time = None
+        self.end_time = None
+        self.create_time = time.time()
+
+        self.mongo_retry = bool(kwargs.get('mongo_retry'))
+
+    @property
+    def execution_duration(self):
+        if None in (self.start_time, self.end_time):
+            raise RequestDurationException("{} can't provide an execution_duration ({}).".format(
+                self, (self.start_time, self.end_time)))
+        return self.end_time - self.start_time
+
+    @property
+    def schedule_delay(self):
+        if None in (self.start_time, self.create_time):
+            raise RequestDurationException("{} can't provide an schedule_delay ({}).".format(
+                self, (self.start_time, self.create_time)))
+        return self.start_time - self.create_time
+
+    @property
+    def total_time(self):
+        if None in (self.end_time, self.create_time):
+            raise RequestDurationException("{} can't provide an total_time ({}).".format(
+                self, (self.end_time, self.create_time)))
+        return self.end_time - self.create_time
+
+    def __str__(self):
+        return "Request id:{} library:{}, symbol:{} fun:{}, kind:{}".format(
+            self.id, self.library, self.symbol, getattr(self.fun, '__name__', None), self.kind)

--- a/arctic/async/async_utils.py
+++ b/arctic/async/async_utils.py
@@ -11,7 +11,7 @@ class AsyncRequestType(Enum):
 
 
 class AsyncRequest(object):
-    def __init__(self, kind, library, fun, *args, **kwargs):
+    def __init__(self, kind, library, fun, callback, *args, **kwargs):
         self.id = uuid.uuid4()
 
         # Request library call spec
@@ -26,6 +26,7 @@ class AsyncRequest(object):
 
         # Request's state
         self.future = None
+        self.callback = callback
         self.data = None
         self.exception = None
         self.is_running = False
@@ -41,21 +42,21 @@ class AsyncRequest(object):
     @property
     def execution_duration(self):
         if None in (self.start_time, self.end_time):
-            raise RequestDurationException("{} can't provide an execution_duration ({}).".format(
+            raise RequestDurationException("{} can't provide an execution_duration {}.".format(
                 self, (self.start_time, self.end_time)))
         return self.end_time - self.start_time
 
     @property
     def schedule_delay(self):
         if None in (self.start_time, self.create_time):
-            raise RequestDurationException("{} can't provide an schedule_delay ({}).".format(
+            raise RequestDurationException("{} can't provide a schedule_delay {}.".format(
                 self, (self.start_time, self.create_time)))
         return self.start_time - self.create_time
 
     @property
     def total_time(self):
         if None in (self.end_time, self.create_time):
-            raise RequestDurationException("{} can't provide an total_time ({}).".format(
+            raise RequestDurationException("{} can't provide a total_time {}.".format(
                 self, (self.end_time, self.create_time)))
         return self.end_time - self.create_time
 

--- a/arctic/exceptions.py
+++ b/arctic/exceptions.py
@@ -56,3 +56,10 @@ class UnorderedDataException(DataIntegrityException):
 class OverlappingDataException(DataIntegrityException):
     pass
 
+
+class AsyncArcticException(ArcticException):
+    pass
+
+
+class RequestDurationException(AsyncArcticException):
+    pass

--- a/benchmarks/async/async_benchmark.py
+++ b/benchmarks/async/async_benchmark.py
@@ -7,8 +7,7 @@ from arctic.async import ASYNC_ARCTIC, async_arctic_submit, async_shutdown, asyn
 from tests.integration.chunkstore.test_utils import create_test_data
 
 
-# a = Arctic('localhost:27017')
-a = Arctic('dlonapahls229:37917')
+a = Arctic('localhost:27017')
 library_name = 'asyncbench.test'
 
 TEST_DATA_CACHE = {}

--- a/benchmarks/async/async_benchmark.py
+++ b/benchmarks/async/async_benchmark.py
@@ -1,0 +1,115 @@
+import time
+from six.moves import xrange
+
+import arctic._compression as aclz4
+from arctic import Arctic
+from arctic.async import ASYNC_ARCTIC, async_arctic_submit, async_join_all, async_wait_requests
+from tests.integration.chunkstore.test_utils import create_test_data
+
+
+a = Arctic('localhost:27017')
+library_name = 'asyncbench.test'
+
+TEST_DATA_CACHE = {}
+
+
+def get_cached_random_df(num_chunks):
+    if num_chunks < 1:
+        raise ValueError("num_chunks must be > 1")
+    if num_chunks not in TEST_DATA_CACHE:
+        TEST_DATA_CACHE[num_chunks] = get_random_df(num_chunks)
+    return TEST_DATA_CACHE[num_chunks]
+
+
+def get_random_df(num_chunks):
+    num_chunks = num_chunks
+    data_to_write = create_test_data(size=25000, index=True, multiindex=False, random_data=True, random_ids=True,
+                                     use_hours=True, date_offset=0, cols=10)
+    data_to_write = data_to_write.append([data_to_write] * (num_chunks - 1))
+    return data_to_write
+
+
+def get_stats(measurements):
+    import numpy as np
+    mean = np.mean(measurements)
+    stdev = np.std(measurements)
+    min = np.min(measurements)
+    max = np.max(measurements)
+    return mean, stdev, min, max
+
+
+def clean_lib():
+    a.delete_library(library_name)
+    a.initialize_library(library_name)
+
+
+def async_bench(num_requests, num_chunks):
+    data = get_cached_random_df(num_chunks)
+    lib = a[library_name]
+    reqs = [async_arctic_submit(lib, lib.write, True, symbol='sym_{}'.format(x), data=data)
+            for x in xrange(num_requests)]
+    async_wait_requests(reqs)
+
+
+def serial_bench(num_requests, num_chunks):
+    data = get_cached_random_df(num_chunks)
+    lib = a[library_name]
+    for x in xrange(num_requests):
+        lib.write(symbol='sym_{}'.format(x), data=data)
+
+
+def run_scenario(result_text, rounds, num_requests, num_chunks, parallel_lz4,
+                 use_async, async_arctic_pool_workers=None):
+    aclz4.enable_parallel_lz4(parallel_lz4)
+    if async_arctic_pool_workers is not None:
+        ASYNC_ARCTIC.reset(block=True, pool_size=int(async_arctic_pool_workers))
+    measurements = []
+    for curr_round in xrange(rounds):
+        # print("Running round {}".format(curr_round))
+        clean_lib()
+        start = time.time()
+        if use_async:
+            async_bench(num_requests, num_chunks)
+        else:
+            serial_bench(num_requests, num_chunks)
+        measurements.append(time.time() - start)
+    print("{}: async={}, chunks/write={}, writes/round={}, rounds={}, "
+          "parallel_lz4={}, async_arctic_pool_workers={}: {}".format(
+        result_text, use_async, num_chunks, num_requests, rounds, parallel_lz4, async_arctic_pool_workers,
+        ["{:.3f}".format(x) for x in get_stats(measurements[1:] if len(measurements) > 1 else measurements)]))
+
+
+def main():
+    n_use_async = (False, True)
+
+    n_rounds = (10,)
+    n_num_requests = (64,)
+    n_num_chunks = (4,)
+
+    n_parallel_lz4 = (False,)
+
+    n_async_arctic_pool_workers = (2, 4, 8)
+
+    for num_chunks in n_num_chunks:
+        for use_async in n_use_async:
+            for async_arctic_pool_workers in (n_async_arctic_pool_workers if use_async else (4,)):
+                for parallel_lz4 in n_parallel_lz4:
+                    for num_requests in n_num_requests:
+                        for rounds in n_rounds:
+                            run_scenario(
+                                result_text="Experiment results",
+                                use_async=use_async,
+                                rounds=rounds,
+                                num_requests=num_requests,
+                                num_chunks=num_chunks,
+                                parallel_lz4=parallel_lz4,
+                                async_arctic_pool_workers=async_arctic_pool_workers)
+
+
+if __name__ == '__main__':
+    main()
+
+# Experiment results: async=False, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=4: ['10.109', '0.000', '10.109', '10.109']
+# Experiment results: async=True, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=2: ['7.169', '0.000', '7.169', '7.169']
+# Experiment results: async=True, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=4: ['5.327', '0.000', '5.327', '5.327']
+# Experiment results: async=True, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=8: ['5.410', '0.000', '5.410', '5.410']

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup(
                    ],
     install_requires=["decorator",
                       "enum-compat",
+                      "futures; python_version == '2.7'",
                       "mockextras",
                       "pandas",
                       "pymongo>=3.6.0",

--- a/tests/integration/test_async_arctic.py
+++ b/tests/integration/test_async_arctic.py
@@ -1,0 +1,5 @@
+import arctic.async as aasync
+
+
+def test_async_arctic():
+    print(aasync.ASYNC_ARCTIC.total_alive_tasks())


### PR DESCRIPTION
Implements feature described in #668 .

This is compatible both with Python 2 and Python 3, without requiring third party libraries.

Currently uses multi-threading, not multi-processing.

The speed gains are roughly 2x for not too large data frames, and 1.5x for large:
```
Experiment results: async=False, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=4: ['11.991', '0.000', '11.991', '11.991']
Experiment results: async=True, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=2: ['7.028', '0.000', '7.028', '7.028']
Experiment results: async=True, chunks/write=2, writes/round=64, rounds=2, parallel_lz4=False, async_arctic_pool_workers=4: ['5.820', '0.000', '5.820', '5.820']
```
The API allows to get back a future, provide a callback, and run with mongo_retry.

May need an extra check for detecting a fork(), and resetting the pool.

The subclassing of AsyncArctic from the abstract LazySingletonWorkersPool, may seem odd, but this is because an upcoming PR (the internal incremental serialization/async-mongo work), reuses the code of LazySingletonWorkersPool. This upcoming PR is orthogonal, and speeds up individual arctic operations.

This PR doesn't cause any regression risks, it only adds new functionality, without affecting existing code paths. The user needs to explicitly invoke the async API, so no surprises for existing code which uses Arctic.

We could improve the usability of the API, but let's first get its nuts and bolts right and agreed.