### PR TITLE
Multiple small formatting changes and enabling pycodestyle in ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 services:
    - mongodb
 
+before_install:
+  - pip install pycodestyle
 install:
   - mongo --version
   - pip install --upgrade pip
@@ -31,3 +33,5 @@ install:
 script:
   - pip freeze
   - python setup.py test --pytest-args=-v
+  # Skipped codes in setup.cfg. Tests not checked for now.
+  - pycodestyle arctic

--- a/arctic/_compression.py
+++ b/arctic/_compression.py
@@ -7,8 +7,9 @@ try:
 except ImportError as e:
     from lz4 import compress as lz4_compress, compressHC as lz4_compressHC, decompress as lz4_decompress
 
+# ENABLE_PARALLEL mutated in global_scope. Do not remove.
 from ._config import ENABLE_PARALLEL, LZ4_HIGH_COMPRESSION, LZ4_WORKERS, LZ4_N_PARALLEL, LZ4_MINSZ_PARALLEL, \
-    BENCHMARK_MODE
+    BENCHMARK_MODE  # noqa # pylint: disable=unused-import
 
 logger = logging.getLogger(__name__)
 
@@ -78,8 +79,10 @@ def compress_array(str_list, withHC=LZ4_HIGH_COMPRESSION):
 
     do_compress = lz4_compressHC if withHC else lz4_compress
 
-    use_parallel = ENABLE_PARALLEL and withHC or \
-                   len(str_list) > LZ4_N_PARALLEL and len(str_list[0]) > LZ4_MINSZ_PARALLEL
+    def can_parallelize_strlist(strlist):
+        return len(strlist) > LZ4_N_PARALLEL and len(strlist[0]) > LZ4_MINSZ_PARALLEL
+
+    use_parallel = (ENABLE_PARALLEL and withHC) or can_parallelize_strlist(str_list)
 
     if BENCHMARK_MODE or use_parallel:
         if _compress_thread_pool is None:

--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -81,7 +81,7 @@ LZ4_WORKERS = os.environ.get('LZ4_WORKERS', 2)
 LZ4_N_PARALLEL = os.environ.get('LZ4_N_PARALLEL', 16)
 
 # Minimum data size to use parallel compression
-LZ4_MINSZ_PARALLEL = os.environ.get('LZ4_MINSZ_PARALLEL', 0.5*1024**2)  # 0.5 MB
+LZ4_MINSZ_PARALLEL = os.environ.get('LZ4_MINSZ_PARALLEL', 0.5 * 1024 ** 2)  # 0.5 MB
 
 # Enable this when you run the benchmark_lz4.py
 BENCHMARK_MODE = False

--- a/arctic/chunkstore/chunkstore.py
+++ b/arctic/chunkstore/chunkstore.py
@@ -742,13 +742,14 @@ class ChunkStore(object):
         res['chunks'] = db.command('collstats', self._collection.name)
         res['symbols'] = db.command('collstats', self._symbols.name)
         res['metadata'] = db.command('collstats', self._mdata.name)
-        res['totals'] = {'count': res['chunks']['count'],
-                         'size': res['chunks']['size'] + res['symbols']['size'] + res['metadata']['size'],
-                        }
+        res['totals'] = {
+            'count': res['chunks']['count'],
+            'size': res['chunks']['size'] + res['symbols']['size'] + res['metadata']['size'],
+        }
         return res
 
     def has_symbol(self, symbol):
-        '''
+        """
         Check if symbol exists in collection
 
         Parameters
@@ -759,5 +760,5 @@ class ChunkStore(object):
         Returns
         -------
         bool
-        '''
+        """
         return self._get_symbol_info(symbol) is not None

--- a/arctic/date/_daterange.py
+++ b/arctic/date/_daterange.py
@@ -82,22 +82,22 @@ class DateRange(GeneralSlice):
         Create a new DateRange representing the maximal range enclosed by this range and other
         """
         startopen = other.startopen if self.start is None \
-                    else self.startopen if other.start is None \
-                    else other.startopen if self.start < other.start \
-                    else self.startopen if self.start > other.start \
-                    else (self.startopen or other.startopen)
+            else self.startopen if other.start is None \
+            else other.startopen if self.start < other.start \
+            else self.startopen if self.start > other.start \
+            else (self.startopen or other.startopen)
         endopen = other.endopen if self.end is None \
-                   else self.endopen if other.end is None \
-                   else other.endopen if self.end > other.end \
-                   else self.endopen if self.end < other.end \
-                   else (self.endopen or other.endopen)
+            else self.endopen if other.end is None \
+            else other.endopen if self.end > other.end \
+            else self.endopen if self.end < other.end \
+            else (self.endopen or other.endopen)
 
         new_start = self.start if other.start is None \
-                    else other.start if self.start is None \
-                    else max(self.start, other.start)
+            else other.start if self.start is None \
+            else max(self.start, other.start)
         new_end = self.end if other.end is None \
-                   else other.end if self.end is None \
-                   else min(self.end, other.end)
+            else other.end if self.end is None \
+            else min(self.end, other.end)
 
         interval = INTERVAL_LOOKUP[(startopen, endopen)]
 

--- a/arctic/date/_util.py
+++ b/arctic/date/_util.py
@@ -85,7 +85,7 @@ def string_to_daterange(str_range, delimiter='-', as_dates=False, interval=CLOSE
 def to_dt(date, default_tz=None):
     """
     Returns a non-naive datetime.datetime.
-    
+
     Interprets numbers as ms-since-epoch.
 
     Parameters
@@ -116,7 +116,7 @@ def to_pandas_closed_closed(date_range, add_tz=True):
 
     Parameters
     ----------
-    date_range : `DateRange` object 
+    date_range : `DateRange` object
         converted to CLOSED_CLOSED form for Pandas slicing
 
     add_tz : `bool`

--- a/arctic/fixtures/arctic.py
+++ b/arctic/fixtures/arctic.py
@@ -35,6 +35,7 @@ def arctic_secondary(mongo_server, arctic):
     arctic = m.Arctic(mongo_host=mongo_server.api, allow_secondary=True)
     return arctic
 
+
 @pytest.fixture(scope="function")
 def multicolumn_store_with_uncompressed_write(mongo_server):
     """

--- a/arctic/scripts/arctic_fsck.py
+++ b/arctic/scripts/arctic_fsck.py
@@ -55,14 +55,14 @@ def main():
                      final_stats['versions'].get('avgObjSize', 0) / 1024. / 1024.))
         logger.info("Versions: %10.2fMB Change(+/-) %.2fMB" %
                     (final_stats['versions']['size'] / 1024. / 1024.,
-                    (final_stats['versions']['size'] - orig_stats['versions']['size']) / 1024. / 1024.))
+                     (final_stats['versions']['size'] - orig_stats['versions']['size']) / 1024. / 1024.))
         logger.info('Chunk Count: %7d   Change(+/-) %6d  (av: %.2fMB)' %
                     (final_stats['chunks']['count'],
                      final_stats['chunks']['count'] - orig_stats['chunks']['count'],
                      final_stats['chunks'].get('avgObjSize', 0) / 1024. / 1024.))
         logger.info("Chunks: %12.2fMB Change(+/-) %6.2fMB" %
                     (final_stats['chunks']['size'] / 1024. / 1024.,
-                    (final_stats['chunks']['size'] - orig_stats['chunks']['size']) / 1024. / 1024.))
+                     (final_stats['chunks']['size'] - orig_stats['chunks']['size']) / 1024. / 1024.))
         logger.info('----------------------------')
 
     if not opts.f:

--- a/arctic/scripts/arctic_init_library.py
+++ b/arctic/scripts/arctic_init_library.py
@@ -26,12 +26,16 @@ def main():
     parser.add_argument("--host", default='localhost', help="Hostname, or clustername. Default: localhost")
     parser.add_argument("--library", help="The name of the library. e.g. 'arctic_jblackburn.lib'")
     parser.add_argument("--type", default=VERSION_STORE, choices=sorted(LIBRARY_TYPES.keys()),
-                                    help="The type of the library, as defined in "
-                                         "arctic.py. Default: %s" % VERSION_STORE)
+                        help="The type of the library, as defined in "
+                             "arctic.py. Default: %s" % VERSION_STORE)
     parser.add_argument("--quota", default=10, help="Quota for the library in GB. A quota of 0 is unlimited."
                                                     "Default: 10")
-    parser.add_argument("--hashed", action="store_true", default=False, help="Use hashed based sharding. Useful where SYMBOLs share a common prefix (e.g. Bloomberg BBGXXXX symbols)"
-                                                        "Default: False")
+    parser.add_argument(
+        "--hashed",
+        action="store_true",
+        default=False,
+        help="Use hashed based sharding. Useful where SYMBOLs share a common prefix (e.g. Bloomberg BBGXXXX symbols) "
+             "Default: False")
 
     opts = parser.parse_args()
 

--- a/arctic/serialization/incremental.py
+++ b/arctic/serialization/incremental.py
@@ -196,23 +196,23 @@ class IncrementalPandasToRecArraySerializer(LazyIncrementalSerializer):
         # Note that the range is: [from_idx, to_idx)
         self._lazy_init()
 
-        my_lenth = len(self)
+        my_length = len(self)
 
         # Take into account default arguments and negative indexing (from end offset)
         from_idx = 0 if from_idx is None else from_idx
         if from_idx < 0:
-            from_idx = my_lenth + from_idx
-        to_idx = my_lenth if to_idx is None else min(to_idx, my_lenth)
+            from_idx = my_length + from_idx
+        to_idx = my_length if to_idx is None else min(to_idx, my_length)
         if to_idx < 0:
-            to_idx = my_lenth + to_idx
+            to_idx = my_length + to_idx
 
         # No data, finish iteration
-        if my_lenth == 0 or from_idx >= my_lenth or from_idx >= to_idx:
+        if my_length == 0 or from_idx >= my_length or from_idx >= to_idx:
             return
 
         # Perform serialization for each chunk
         while from_idx < to_idx:
-            curr_stop = min(from_idx+self._rows_per_chunk, to_idx)
+            curr_stop = min(from_idx + self._rows_per_chunk, to_idx)
 
             chunk, _ = self._serializer.serialize(
                 self.input_data[from_idx: curr_stop],

--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -186,7 +186,7 @@ class FrametoArraySerializer(Serializer):
         return ret
 
     def deserialize(self, data, columns=None):
-        '''
+        """
         Deserializes SON to a DataFrame
 
         Parameters
@@ -199,8 +199,8 @@ class FrametoArraySerializer(Serializer):
         Returns
         -------
         pandas dataframe or series
-        '''
-        if data == []:
+        """
+        if not data:
             return pd.DataFrame()
 
         meta = data[0][METADATA] if isinstance(data, list) else data[METADATA]

--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 from pandas import DataFrame, MultiIndex, Series, DatetimeIndex, Index
 
+# Used in global scope, do not remove.
 from .._config import FAST_CHECK_DF_SERIALIZABLE
 from .._util import NP_OBJECT_DTYPE
 from ..exceptions import ArcticException

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -46,9 +46,7 @@ class PandasStore(NdarrayStore):
             new_segments = np.array(new_segments, dtype='i8')
             last_rows = recarr[new_segments - start]
             # create numpy index
-            index = np.core.records.fromarrays([last_rows[idx_col]]
-                                               + [new_segments, ],
-                                               dtype=INDEX_DTYPE)
+            index = np.core.records.fromarrays([last_rows[idx_col]] + [new_segments, ], dtype=INDEX_DTYPE)
             # append to existing index if exists
             if existing_index:
                 # existing_index_arr is read-only but it's never written to

--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -26,11 +26,11 @@ class PickleStore(object):
     def initialize_library(cls, *args, **kwargs):
         pass
 
-    def get_info(self, version):
-        ret = {}
-        ret['type'] = 'blob'
-        ret['handler'] = self.__class__.__name__
-        return ret
+    def get_info(self, _version):
+        return {
+            'type': 'blob',
+            'handler': self.__class__.__name__,
+        }
 
     def read(self, mongoose_lib, version, symbol, **kwargs):
         blob = version.get("blob")

--- a/arctic/store/_version_store_utils.py
+++ b/arctic/store/_version_store_utils.py
@@ -80,7 +80,7 @@ def _cleanup_parent_pointers(collection, symbol, version_ids):
 
     # Now remove all chunks which aren't parented - this is unlikely, as they will
     # have been removed by the above
-    collection.delete_one({'symbol':  symbol, 'parent': []})
+    collection.delete_one({'symbol': symbol, 'parent': []})
 
 
 def _cleanup_mixed(symbol, collection, version_ids, versions_coll):
@@ -228,7 +228,7 @@ def analyze_symbol(l, sym, from_ver, to_ver, do_reads=False):
                 delta_snap_creation,
                 'PREV_MISSING' if prev_n < n - 1 else '',
                 'CORRUPTED VERSION' if corrupted else '')
-            )
+        )
         prev_rows = v.get('up_to', 0)
         prev_n = n
         prev_v = v

--- a/arctic/store/audit.py
+++ b/arctic/store/audit.py
@@ -24,7 +24,7 @@ class DataChange(object):
 
 
 class ArcticTransaction(object):
-    '''Use this context manager if you want to modify data in a version store while ensuring that no other writes
+    """Use this context manager if you want to modify data in a version store while ensuring that no other writes
     interfere with your own.
 
     To use, base your modifications on the `base_ts` context manager field and put your newly created timeseries and
@@ -43,10 +43,10 @@ class ArcticTransaction(object):
     The block will raise a ConcurrentModificationException if an inconsistency has been detected. You will have to
     retry the whole block should that happens, as the assumption is that you need to base your changes on a different
     starting timeseries.
-    '''
+    """
     def __init__(self, version_store, symbol, user, log, modify_timeseries=None, audit=True,
                  *args, **kwargs):
-        '''
+        """
         Parameters
         ----------
         version_store: `VersionStore` Arctic Library
@@ -76,7 +76,7 @@ class ArcticTransaction(object):
 
         all other args:
             Will be passed into the initial read
-        '''
+        """
         self._version_store = version_store
         self._symbol = symbol
         self._user = user
@@ -84,8 +84,7 @@ class ArcticTransaction(object):
         self._audit = audit
         logger.info("MT: {}@{}: [{}] {}: {}".format(_get_host(version_store).get('l'),
                                                     _get_host(version_store).get('mhost'),
-                                                       user, log, symbol)
-                    )
+                                                    user, log, symbol))
         try:
             self.base_ts = self._version_store.read(self._symbol, *args, **kwargs)
         except NoDataFoundException:
@@ -117,9 +116,10 @@ class ArcticTransaction(object):
         pass
 
     def write(self, symbol, data, prune_previous_version=True, metadata=None, **kwargs):
-        '''Records a write request to be actioned on context exit. Takes exactly the same parameters as the regular
+        """
+        Records a write request to be actioned on context exit. Takes exactly the same parameters as the regular
         library write call.
-        '''
+        """
         if data is not None:
             # We only write data if existing data is None or the Timeseries data has changed or metadata has changed
             if self.base_ts.data is None or not are_equals(data, self.base_ts.data) or metadata != self.base_ts.metadata:

--- a/arctic/store/bson_store.py
+++ b/arctic/store/bson_store.py
@@ -9,6 +9,7 @@ logger = logging.getLogger(__name__)
 
 BSON_STORE_TYPE = 'BSONStore'
 
+
 class BSONStore(object):
     """
     BSON Data Store. This stores any Python object that encodes to BSON correctly,

--- a/arctic/store/metadata_store.py
+++ b/arctic/store/metadata_store.py
@@ -89,7 +89,8 @@ class MetadataStore(BSONStore):
 
         if regex or as_of:
             # make sure that symbol is present in query even if only as_of is specified to avoid document scans
-            # see 'Pipeline Operators and Indexes' at https://docs.mongodb.com/manual/core/aggregation-pipeline/#aggregation-pipeline-operators-and-performance
+            # see 'Pipeline Operators and Indexes' at
+            # https://docs.mongodb.com/manual/core/aggregation-pipeline/#aggregation-pipeline-operators-and-performance
             index_query['symbol'] = {'$regex': regex or '^'}
 
         # Document query part
@@ -224,7 +225,7 @@ class MetadataStore(BSONStore):
             return
 
         self.find_one_and_update({'symbol': symbol}, {'$set': {'end_time': start_time}},
-                                  sort=[('start_time', pymongo.DESCENDING)])
+                                 sort=[('start_time', pymongo.DESCENDING)])
         document = {'_id': bson.ObjectId(), 'symbol': symbol, 'metadata': metadata, 'start_time': start_time}
         mongo_retry(self.insert_one)(document)
 

--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -689,10 +689,10 @@ class VersionStore(object):
         # It is dangerous because if it deletes the version at the last_look, the segments added by the
         # append are dangling (if prune_previous_version is False) and can cause potentially corruption.
         constraints = new_version and \
-                            reference_version and \
-                            new_version['symbol'] == reference_version['symbol'] and \
-                            new_version['_id'] != reference_version['_id'] and \
-                            new_version['base_version_id']
+                      reference_version and \
+                      new_version['symbol'] == reference_version['symbol'] and \
+                      new_version['_id'] != reference_version['_id'] and \
+                      new_version['base_version_id']
         assert constraints
         # There is always a small risk here another process in between these two calls (above/below)
         # to delete the reference_version, which may happen to be the last parent entry in the data segments.

--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -195,16 +195,16 @@ class TickStore(object):
             match.update({'s': {'$lte': start}})
 
             result = self._collection.aggregate([
-                            # Only look at the symbols we are interested in and chunks that
-                            # start before our start datetime
-                            {'$match': match},
-                            # Throw away everything but the start of every chunk and the symbol
-                            {'$project': {'_id': 0, 's': 1, 'sy': 1}},
-                            # For every symbol, get the latest chunk start (that is still before
-                            # our sought start)
-                            {'$group': {'_id': '$sy', 'start': {'$max': '$s'}}},
-                            {'$sort': {'start': 1}},
-                            ])
+                # Only look at the symbols we are interested in and chunks that
+                # start before our start datetime
+                {'$match': match},
+                # Throw away everything but the start of every chunk and the symbol
+                {'$project': {'_id': 0, 's': 1, 'sy': 1}},
+                # For every symbol, get the latest chunk start (that is still before
+                # our sought start)
+                {'$group': {'_id': '$sy', 'start': {'$max': '$s'}}},
+                {'$sort': {'start': 1}},
+            ])
             # Now we need to get the earliest start of the chunk that still spans the start point.
             # Since we got them sorted by start, we just need to fetch their ends as well and stop
             # when we've seen the first such chunk
@@ -226,8 +226,8 @@ class TickStore(object):
             logger.info("No end provided.  Loading a month for: {}:{}".format(symbol, first_dt))
             if not first_dt:
                 first_doc = self._collection.find_one(self._symbol_query(symbol),
-                                                  projection={START: 1, ID: 0},
-                                                  sort=[(START, pymongo.ASCENDING)])
+                                                      projection={START: 1, ID: 0},
+                                                      sort=[(START, pymongo.ASCENDING)])
                 if not first_doc:
                     raise NoDataFoundException()
 
@@ -294,19 +294,19 @@ class TickStore(object):
 
         if columns:
             projection = dict([(SYMBOL, 1),
-                           (INDEX, 1),
-                           (START, 1),
-                           (VERSION, 1),
-                           (IMAGE_DOC, 1)] +
-                          [(COLUMNS + '.%s' % c, 1) for c in columns])
+                               (INDEX, 1),
+                               (START, 1),
+                               (VERSION, 1),
+                               (IMAGE_DOC, 1)] +
+                              [(COLUMNS + '.%s' % c, 1) for c in columns])
             column_set.update([c for c in columns if c != 'SYMBOL'])
         else:
             projection = dict([(SYMBOL, 1),
-                           (INDEX, 1),
-                           (START, 1),
-                           (VERSION, 1),
-                           (COLUMNS, 1),
-                           (IMAGE_DOC, 1)])
+                               (INDEX, 1),
+                               (START, 1),
+                               (VERSION, 1),
+                               (COLUMNS, 1),
+                               (IMAGE_DOC, 1)])
 
         column_dtypes = {}
         ticks_read = 0
@@ -338,7 +338,7 @@ class TickStore(object):
         if len(index) > 0:
             arrays = [np.concatenate(rtn[k]) for k in columns]
         else:
-            arrays = [[] for k in columns]
+            arrays = [[] for _ in columns]
 
         if multiple_symbols:
             sort = np.argsort(index, kind='mergesort')
@@ -543,15 +543,16 @@ class TickStore(object):
                                          START: {'$lt': end}
                                          },
                                         projection={START: 1,
-                                                END: 1,
-                                                '_id': 0},
+                                                    END: 1,
+                                                    '_id': 0},
                                         sort=[(START, pymongo.DESCENDING)])
         if doc:
             if not doc[END].tzinfo:
                 doc[END] = doc[END].replace(tzinfo=mktz('UTC'))
             if doc[END] > start:
-                raise OverlappingDataException("Document already exists with start:{} end:{} in the range of our start:{} end:{}".format(
-                                                            doc[START], doc[END], start, end))
+                raise OverlappingDataException(
+                    "Document already exists with start:{} end:{} in the range of our start:{} end:{}".format(
+                        doc[START], doc[END], start, end))
 
     def write(self, symbol, data, initial_image=None, metadata=None):
         """
@@ -592,9 +593,9 @@ class TickStore(object):
         self._write(buckets)
 
         if metadata:
-            ret = self._metadata.replace_one({SYMBOL: symbol},
-                                             {SYMBOL: symbol, META: metadata},
-                                             upsert=True)
+            self._metadata.replace_one({SYMBOL: symbol},
+                                       {SYMBOL: symbol, META: metadata},
+                                       upsert=True)
 
     def _write(self, buckets):
         start = dt.now()
@@ -632,13 +633,13 @@ class TickStore(object):
         Represent dtypes without byte order, as earlier Java tickstore code doesn't support explicit byte order.
         """
         assert dtype.byteorder != '>'
-        if (dtype.kind) == 'i':
+        if dtype.kind == 'i':
             assert dtype.itemsize == 8
             return 'int64'
-        elif (dtype.kind) == 'f':
+        elif dtype.kind == 'f':
             assert dtype.itemsize == 8
             return 'float64'
-        elif (dtype.kind) == 'U':
+        elif dtype.kind == 'U':
             return 'U%d' % (dtype.itemsize / 4)
         else:
             raise UnhandledDtypeException("Bad dtype '%s'" % dtype)
@@ -646,12 +647,12 @@ class TickStore(object):
     @staticmethod
     def _ensure_supported_dtypes(array):
         # We only support these types for now, as we need to read them in Java
-        if (array.dtype.kind) == 'i':
+        if array.dtype.kind == 'i':
             array = array.astype('<i8')
-        elif (array.dtype.kind) == 'f':
+        elif array.dtype.kind == 'f':
             array = array.astype('<f8')
-        elif (array.dtype.kind) in ('O', 'U', 'S'):
-            if (array.dtype.kind) == 'O' and infer_dtype(array) not in ['unicode', 'string', 'bytes']:
+        elif array.dtype.kind in ('O', 'U', 'S'):
+            if array.dtype.kind == 'O' and infer_dtype(array) not in ['unicode', 'string', 'bytes']:
                 # `string` in python2 and `bytes` in python3
                 raise UnhandledDtypeException("Casting object column to string failed")
             try:
@@ -682,13 +683,12 @@ class TickStore(object):
     def _pandas_to_bucket(df, symbol, initial_image):
         rtn = {SYMBOL: symbol, VERSION: CHUNK_VERSION_NUMBER, COLUMNS: {}, COUNT: len(df)}
         end = to_dt(df.index[-1].to_pydatetime())
-        if initial_image :
+        if initial_image:
             if 'index' in initial_image:
                 start = min(to_dt(df.index[0].to_pydatetime()), initial_image['index'])
             else:
                 start = to_dt(df.index[0].to_pydatetime())
             image_start = initial_image.get('index', start)
-            image = {k: v for k, v in initial_image.items() if k != 'index'}
             rtn[IMAGE_DOC] = {IMAGE_TIME: image_start, IMAGE: initial_image}
             final_image = TickStore._pandas_compute_final_image(df, initial_image, end)
         else:
@@ -704,13 +704,17 @@ class TickStore(object):
         recs = df.to_records(convert_datetime64=False)
         for col in df:
             array = TickStore._ensure_supported_dtypes(recs[col])
-            col_data = {}
-            col_data[DATA] = Binary(lz4_compressHC(array.tostring()))
-            col_data[ROWMASK] = rowmask
-            col_data[DTYPE] = TickStore._str_dtype(array.dtype)
+            col_data = {
+                DATA: Binary(lz4_compressHC(array.tostring())),
+                ROWMASK: rowmask,
+                DTYPE: TickStore._str_dtype(array.dtype),
+            }
             rtn[COLUMNS][col] = col_data
-        rtn[INDEX] = Binary(lz4_compressHC(np.concatenate(([recs[index_name][0].astype('datetime64[ms]').view('uint64')],
-                                                           np.diff(recs[index_name].astype('datetime64[ms]').view('uint64')))).tostring()))
+        rtn[INDEX] = Binary(
+            lz4_compressHC(np.concatenate(
+                ([recs[index_name][0].astype('datetime64[ms]').view('uint64')],
+                 np.diff(
+                     recs[index_name].astype('datetime64[ms]').view('uint64')))).tostring()))
         return rtn, final_image
 
     @staticmethod
@@ -732,7 +736,7 @@ class TickStore(object):
                         v = TickStore._to_ms(v)
                         if data[k][-1] > v:
                             raise UnorderedDataException("Timestamps out-of-order: %s > %s" % (
-                                                          ms_to_datetime(data[k][-1]), t))
+                                ms_to_datetime(data[k][-1]), t))
                     data[k].append(v)
                 except KeyError:
                     if k != 'index':
@@ -754,7 +758,7 @@ class TickStore(object):
             image_start = initial_image.get('index', start)
             if image_start > start:
                 raise UnorderedDataException("Image timestamp is after first tick: %s > %s" % (
-                                              image_start, start))
+                    image_start, start))
             start = min(start, image_start)
             rtn[IMAGE_DOC] = {IMAGE_TIME: image_start, IMAGE: initial_image}
         rtn[END] = end

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[pycodestyle]
+ignore = E122,E126,E501,E731,W503,E722,W504

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -14,6 +14,7 @@ from six import StringIO
 
 from arctic._compression import decompress
 from arctic.date import DateRange, mktz
+# Do not remove PandasStore, used in global scope
 from arctic.store._pandas_ndarray_store import PandasDataFrameStore, PandasSeriesStore, PandasStore
 from arctic.store.version_store import register_versioned_storage
 

--- a/tests/unit/store/test_pandas_ndarray_store.py
+++ b/tests/unit/store/test_pandas_ndarray_store.py
@@ -2,6 +2,7 @@ import numpy as np
 from mock import Mock, sentinel, patch
 from pytest import raises
 
+# Do not remove PandasStore
 from arctic.store._pandas_ndarray_store import PandasDataFrameStore, PandasPanelStore, PandasStore
 from tests.util import read_str_as_pandas
 


### PR DESCRIPTION
This has multiple small changes made as was browsing the code. Fixes mostly fall into these categories:
* double quote in docstrings
* remove unnecessary brackets
* marking unused imports
* initializing dicts in one go
* Indents
* Variable renames

Also enabled pycodestyle with some disabled flags (eg. line length etc are disabled). The advantage being if any of the fixed issues now break, it will not allow that change. 

`pycodestyle --ignore=E122,E126,E223,E501,E731,W503,E722,W504 arctic`
should pass from now on.
