### PR TITLE
Revert "Set theme jekyll-theme-cayman"

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
This reverts commit 44a202de7524d7152aa6f4d2bcb2dfe21807b9ad.
Github apparently commits this straight to master on trying out
githubpages, was not intentional.