### PR TITLE
Fix build by pinning pytest<4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
                      ],
     tests_require=["mock",
                    "mockextras",
-                   "pytest",
+                   "pytest<4.1",
                    "pytest-cov",
                    "pytest-server-fixtures",
                    "pytest-timeout",


### PR DESCRIPTION
Pinning pytest to <4.1 to fix this: 
https://github.com/manahl/arctic/issues/678

Not sure when pytest-cov will release next, this should unblock us for now.