### PR TITLE
Unpin pytest-cov

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,10 +90,11 @@ setup(
                       "tzlocal",
                       "lz4"
                      ],
+    # Note: pytest >= 4.1.0 is not compatible with pytest-cov < 2.6.1.
     tests_require=["mock",
                    "mockextras",
                    "pytest",
-                   "pytest-cov>=2.6.1",
+                   "pytest-cov",
                    "pytest-server-fixtures",
                    "pytest-timeout",
                    "pytest-xdist",


### PR DESCRIPTION
Internal builds might not have latest versions of pytest-cov and
the pinning might conflict there. The expectation is that whoever
upgrades pytest internally will upgraded pytest-cov as well.

In travis the latest versions of pytest-cov and pytest should be
fine.