### PR TITLE
Add a cached version of list_libraries

### DIFF
--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -92,3 +92,9 @@ BENCHMARK_MODE = False
 # ---------------------------
 # Configures the size of the workers pools used for async arctic requests
 ARCTIC_ASYNC_NWORKERS = os.environ.get('ARCTIC_ASYNC_NWORKERS', 4)
+
+
+# -------------------------------
+# Flag used for indicating caching levels. For now just for list_libraries.
+# -------------------------------
+ENABLE_CACHE = bool(os.environ.get('ENABLE_CACHE'))

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -191,7 +191,13 @@ class Arctic(object):
         -------
         list of Arctic library names
         """
-        return self._list_libraries_cached() if ENABLE_CACHE else self._list_libraries()
+        if ENABLE_CACHE:
+            try:
+                return self._list_libraries_cached()
+            except OperationFailure as exc:
+                logging.warning("Could not fetch from cache due to %s", exc)
+
+        return self._list_libraries()
 
     @mongo_retry
     def _list_libraries(self):

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -309,6 +309,12 @@ class Arctic(object):
         if not lib.get_quota():
             lib.set_quota(10 * 1024 * 1024 * 1024)
 
+        # Try to clean cache whether it's enabled or not.
+        try:
+            self.invalidate_cache()
+        except OperationFailure as exc:
+            logging.warning('Could not invalidate cache due to %s', exc)
+
     @mongo_retry
     def delete_library(self, library):
         """

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -277,3 +277,27 @@ def test_invalidate_cache(arctic):
     # Invalidate cache and check that the cache is empty
     arctic.invalidate_cache()
     assert list(mongo.meta_db.cache.find()) == []
+
+
+def test_initialize_library_invalidates_cache(arctic):
+    libs = ['test1', 'test2']
+
+    for lib in libs:
+        arctic.initialize_library(lib)
+
+    assert arctic._list_libraries_cached() == arctic._list_libraries()
+
+    mongo = arctic._conn
+
+    # Should have data in cache as list_libraries_cached was called
+    assert list(mongo.meta_db.cache.find()) != []
+
+    # Add another lib
+    arctic.initialize_library('test3')
+
+    # Cache should be empty
+    assert list(mongo.meta_db.cache.find()) == []
+
+    # List libraries should repopulate the cache
+    arctic._list_libraries_cached()
+    assert len(list(mongo.meta_db.cache.find())) != []


### PR DESCRIPTION
list_libraries is a frequently called operation that can get
quite slow with a high amount of libraries. I noticed 4-5s+
for 7-8k libraries. Also the number of libraries is fairly
constant, so not much point in refetching the entire list every
time.

This adds a new collection in mongo which acts as a global cache
for all queries. For now it's called list_libraries_cache but I
guess long term we can have: list_libraries(cached=True).