### PR TITLE
683: Fix arrays_to_mgr for pandas 0.23.4

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -8,10 +8,15 @@ import numpy as np
 import pandas as pd
 import pymongo
 from bson.binary import Binary
-from pandas.core.frame import _arrays_to_mgr
 from pymongo import ReadPreference
 from pymongo.errors import OperationFailure
 from six import iteritems, string_types
+
+try:
+    from pandas.core.frame import _arrays_to_mgr
+except ImportError:
+    # Deprecated since pandas 0.23.4
+    from pandas.core.internals.construction import arrays_to_mgr as _arrays_to_mgr
 
 try:
     from pandas.api.types import infer_dtype


### PR DESCRIPTION
This is to unblock us till we decide on the proper way to do
pinning or using a different setup for versioning.