### PR TITLE
Fix no handler in logging warning

### DIFF
--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -18,7 +18,9 @@ from .tickstore import tickstore, toplevel
 
 __all__ = ['Arctic', 'VERSION_STORE', 'METADATA_STORE', 'TICK_STORE', 'CHUNK_STORE', 'register_library_type']
 
+# Set default logging handler to avoid "No handler found" warnings.
 logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
 
 # Default Arctic application name: 'arctic'
 APPLICATION_NAME = 'arctic'


### PR DESCRIPTION
Adds basic logging to prevent the warning in: https://github.com/manahl/arctic/issues/27 similar to https://github.com/requests/requests/blob/master/requests/__init__.py#L124

