### PR TITLE
Fixes #710: Initialize SEGMENT_SHA in versions for writes and appends

### DIFF
--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -409,6 +409,9 @@ class NdarrayStore(object):
 
         version['type'] = self.TYPE
         version[FW_POINTERS_CONFIG_KEY] = ARCTIC_FORWARD_POINTERS_CFG.name
+        # Create an empty entry to prevent cases where this field is accessed without being there. (#710)
+        if version[FW_POINTERS_CONFIG_KEY] != FwPointersCfg.DISABLED.name:
+            version[FW_POINTERS_REFS_KEY] = list()
 
         if str(dtype) != previous_version['dtype'] or \
                 _fw_pointers_convert_append_to_write(previous_version):
@@ -611,6 +614,9 @@ class NdarrayStore(object):
         version['up_to'] = len(item)
         version['sha'] = self.checksum(item)
         version[FW_POINTERS_CONFIG_KEY] = ARCTIC_FORWARD_POINTERS_CFG.name
+        # Create an empty entry to prevent cases where this field is accessed without being there. (#710)
+        if version[FW_POINTERS_CONFIG_KEY] != FwPointersCfg.DISABLED.name:
+            version[FW_POINTERS_REFS_KEY] = list()
 
         if previous_version:
             if 'sha' in previous_version \


### PR DESCRIPTION
This would help preventing issues where we are accessing this key
in versions without being initialized.

This is only done for cases where it's either HYBRID or ENABLED
mode as this field should not be used in other cases anyways.