### PR TITLE
Fix #587 Add a best effort cache option for list_libraries

### DIFF
--- a/arctic/_cache.py
+++ b/arctic/_cache.py
@@ -1,0 +1,67 @@
+import logging
+from datetime import datetime, timedelta
+
+from pymongo.errors import OperationFailure
+
+from ._config import CACHE_COLL, CACHE_DB
+
+logger = logging.getLogger(__name__)
+
+
+class Cache:
+    def __init__(self, client, cache_expiry=3600, cache_db=CACHE_DB, cache_col=CACHE_COLL):
+        self._client = client
+        self._cachedb = client[cache_db]
+        self._cachecol = None
+        try:
+            if cache_col not in self._cachedb.collection_names():
+                self._cachedb.create_collection(cache_col).create_index("date", expireAfterSeconds=cache_expiry)
+        except OperationFailure as op:
+            logging.debug("This is fine if you are not admin. The collection should already be created for you: %s", op)
+
+        self._cachecol = self._cachedb[cache_col]
+
+    def get(self, key, newer_than_secs=-1):
+        """
+
+        :param key: Key for the dataset. eg. list_libraries.
+        :param newer_than_secs: -1 to indicate use cache if available. Used to indicate what level of staleness
+        in seconds is tolerable.
+        :return: None unless if there is non stale data present in the cache.
+        """
+        try:
+            if not self._cachecol:
+                # Collection not created or no permissions to read from it.
+                return None
+            coll_data = self._cachecol.find_one({"type": key})
+            # Check that there is data in cache and it's not stale.
+            if coll_data and (
+                    newer_than_secs == -1 or
+                    datetime.utcnow() < coll_data['date'] + timedelta(seconds=newer_than_secs)
+            ):
+                return coll_data['data']
+        except OperationFailure as op:
+            logging.warning("Could not read from cache due to: %s. Ask your admin to give read permissions on %s:%s",
+                            op, CACHE_DB, CACHE_COLL)
+
+        return None
+
+    def set(self, key, data):
+        try:
+            self._cachecol.update_one(
+                {"type": key},
+                {"$set": {"type": key, "date": datetime.utcnow(), "data": data}},
+                upsert=True
+            )
+        except OperationFailure as op:
+            logging.debug("This operation is to be run with admin permissions. Should be fine: %s", op)
+
+    def append(self, key, append_data):
+        # Not upserting here as this is meant to be use when there is already data for this key.
+        try:
+            self._cachecol.update_one(
+                {'type': key},
+                {'$push': {'data': append_data}}
+            )
+        except OperationFailure as op:
+            logging.debug("Admin is required to append to the cache: %s", op)

--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -92,3 +92,11 @@ BENCHMARK_MODE = False
 # ---------------------------
 # Configures the size of the workers pools used for async arctic requests
 ARCTIC_ASYNC_NWORKERS = os.environ.get('ARCTIC_ASYNC_NWORKERS', 4)
+
+
+# -------------------------------
+# Flag used for indicating caching levels. For now just for list_libraries.
+# -------------------------------
+ENABLE_CACHE = not bool(os.environ.get('DISABLE_CACHE'))
+CACHE_COLL = 'cache'
+CACHE_DB = 'meta_db'


### PR DESCRIPTION
list_libraries is a frequently called operation that can get
quite slow with a high amount of libraries. I noticed 4-5s+
for 7-8k libraries. Also the number of libraries is fairly
constant, so not much point in refetching the entire list every
time.

This adds a new collection in mongo which acts as a global cache
for all queries. The meta_db can be used for more accounting and
metadata storage in future, and this collection can be used for
caching other stuff as well.

It's best effort as if you don't have permissions or the data
does not exist in the cache it will just use the list_libraries.
The idea is to not require admin for reads and not expect the user
to have write access to a collection on writes.