### PR TITLE
Upsert append

### DIFF
--- a/arctic/_cache.py
+++ b/arctic/_cache.py
@@ -58,7 +58,7 @@ class Cache:
 
     def append(self, key, append_data):
         try:
-            self._cachecol.update_one(
+            self._cachecol.update(
                 {'type': key},
                 {
                     # Add to set will not add the same library again to the list unlike set.
@@ -69,3 +69,17 @@ class Cache:
             )
         except OperationFailure as op:
             logging.debug("Admin is required to append to the cache: %s", op)
+
+    def delete_item_from_key(self, key, item):
+        try:
+            self._cachecol.update(
+                {'type': key},
+                {"$pull": {"data": item}}
+            )
+        except OperationFailure as op:
+            logging.debug("Admin is required to remove from cache: %s", op)
+
+    def update_item_for_key(self, key, old, new):
+        # This op is not atomic, but given the rarity of renaming a lib, it should not cause issues.
+        self.delete_item_from_key(key, old)
+        self.append(key, new)

--- a/arctic/_cache.py
+++ b/arctic/_cache.py
@@ -57,11 +57,15 @@ class Cache:
             logging.debug("This operation is to be run with admin permissions. Should be fine: %s", op)
 
     def append(self, key, append_data):
-        # Not upserting here as this is meant to be use when there is already data for this key.
         try:
             self._cachecol.update_one(
                 {'type': key},
-                {'$push': {'data': append_data}}
+                {
+                    # Add to set will not add the same library again to the list unlike set.
+                    '$addToSet': {'data': append_data},
+                    '$setOnInsert': {'type': key, 'date': datetime.utcnow()}
+                },
+                upsert=True
             )
         except OperationFailure as op:
             logging.debug("Admin is required to append to the cache: %s", op)

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -229,6 +229,7 @@ class Arctic(object):
         return self._list_libraries()
 
     def reload_cache(self):
+        _ = self._conn  # Ensures the connection exists and cache is initialized with it.
         self._cache.set('list_libraries', self._list_libraries())
 
     def library_exists(self, library):

--- a/arctic/arctic.py
+++ b/arctic/arctic.py
@@ -266,7 +266,6 @@ class Arctic(object):
 
         return library
 
-
     @mongo_retry
     def initialize_library(self, library, lib_type=VERSION_STORE, **kwargs):
         """


### PR DESCRIPTION
Fixes 2 things:

a) Initialize library will now add to cache even if the cache is empty by upserting. This is required as an user might be caught out when trying out arctic by just adding a lib and doing list_libraries. If sufficient permissions do not exist, it will silently skip this operation.

b) If reload_cache was the first op after initializing arctic, the connection might not yet be created. This ensures it.