### PR TITLE
Fix conversion error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ from setuptools.command.test import test as TestCommand
 # http://stackoverflow.com/a/26737672
 try:
     import pypandoc
-    long_description = pypandoc.convert('README.md', 'rst')
-    changelog = pypandoc.convert('CHANGES.md', 'rst')
+    long_description = pypandoc.convert_file('README.md', 'rst', format='markdown_github')
+    changelog = pypandoc.convert_file('CHANGES.md', 'rst', format='markdown_github')
 except (IOError, ImportError, OSError):
     long_description = open('README.md').read()
     changelog = open('CHANGES.md').read()


### PR DESCRIPTION
pypandoc deprecated the old function and does not render correctly with RST anymore (unless you specify the markdown flavor)


see https://pypi.org/project/arctic/

the project description is all broken. It will look much better once this is merged and another release is done

