### PR TITLE
Fix the case of moving from disabled to hybrid / fwd mode

### DIFF
--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -134,8 +134,8 @@ def _update_fw_pointers(collection, symbol, version, previous_version, is_append
     if is_append:
         # Appends are tricky, as we extract the SHAs from the previous version (assuming it has FW pointers info)
         prev_fw_cfg = get_fwptr_config(previous_version)
-        if prev_fw_cfg is FwPointersCfg.DISABLED.name:
-            version_shas.update(Binary(sha) for sha in collection.find(
+        if prev_fw_cfg == FwPointersCfg.DISABLED.name or FW_POINTERS_REFS_KEY not in previous_version:
+            version_shas.update(Binary(sha['sha']) for sha in collection.find(
                 {'symbol': symbol,
                  'parent': version_base_or_id(previous_version),
                  'segment': {'$lt': previous_version['up_to']}},

--- a/arctic/store/_ndarray_store.py
+++ b/arctic/store/_ndarray_store.py
@@ -409,9 +409,6 @@ class NdarrayStore(object):
 
         version['type'] = self.TYPE
         version[FW_POINTERS_CONFIG_KEY] = ARCTIC_FORWARD_POINTERS_CFG.name
-        # Create an empty entry to prevent cases where this field is accessed without being there. (#710)
-        if version[FW_POINTERS_CONFIG_KEY] != FwPointersCfg.DISABLED.name:
-            version[FW_POINTERS_REFS_KEY] = list()
 
         if str(dtype) != previous_version['dtype'] or \
                 _fw_pointers_convert_append_to_write(previous_version):
@@ -614,9 +611,6 @@ class NdarrayStore(object):
         version['up_to'] = len(item)
         version['sha'] = self.checksum(item)
         version[FW_POINTERS_CONFIG_KEY] = ARCTIC_FORWARD_POINTERS_CFG.name
-        # Create an empty entry to prevent cases where this field is accessed without being there. (#710)
-        if version[FW_POINTERS_CONFIG_KEY] != FwPointersCfg.DISABLED.name:
-            version[FW_POINTERS_REFS_KEY] = list()
 
         if previous_version:
             if 'sha' in previous_version \

--- a/tests/integration/store/test_version_store.py
+++ b/tests/integration/store/test_version_store.py
@@ -1131,6 +1131,48 @@ def test_append_after_empty(library, fw_pointers_cfg):
         assert_frame_equal(df, r.data)
 
 
+def test_disable_then_hybrid_fwd_ptr_with_append(library):
+    with FwPointersCtx(FwPointersCfg.DISABLED):
+        len_df = 500
+        index = [dt(2017, 1, 2)] * len_df
+        data = np.random.random((len_df, 10))
+        df = pd.DataFrame(index=index, data=data)
+        df.index.name = 'index'
+        df.columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+        library.write(symbol, df.iloc[:0])
+
+        for i in range(0, 250):
+            library.append(symbol, df.iloc[i:i + 1])
+
+    with FwPointersCtx(FwPointersCfg.HYBRID):
+        for i in range(250, 500):
+            library.append(symbol, df.iloc[i:i + 1])
+
+        r = library.read(symbol)
+        assert_frame_equal(df, r.data)
+
+
+def test_disable_then_enable_fwd_ptr_with_append(library):
+    with FwPointersCtx(FwPointersCfg.DISABLED):
+        len_df = 500
+        index = [dt(2017, 1, 2)] * len_df
+        data = np.random.random((len_df, 10))
+        df = pd.DataFrame(index=index, data=data)
+        df.index.name = 'index'
+        df.columns = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j']
+        library.write(symbol, df.iloc[:0])
+
+        for i in range(0, 250):
+            library.append(symbol, df.iloc[i:i + 1])
+
+    with FwPointersCtx(FwPointersCfg.ENABLED):
+        for i in range(250, 500):
+            library.append(symbol, df.iloc[i:i + 1])
+
+        r = library.read(symbol)
+        assert_frame_equal(df, r.data)
+
+
 def _rnd_df(nrows, ncols):
     ret_df = pd.DataFrame(np.random.randn(nrows, ncols),
                           index=pd.date_range('20170101',


### PR DESCRIPTION
Currently we have issues when moving from disabled -> fwd mode with preexisting data. This was because:
a) usage of 'is' vs '=='
b) using the returned find results vs the 'sha' of the objects.