### PR TITLE
Add a way to force bytes columns to unicode via a config flag

### DIFF
--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -100,3 +100,9 @@ ARCTIC_ASYNC_NWORKERS = os.environ.get('ARCTIC_ASYNC_NWORKERS', 4)
 ENABLE_CACHE = not bool(os.environ.get('DISABLE_CACHE'))
 CACHE_COLL = 'cache'
 CACHE_DB = 'meta_db'
+
+# -------------------------------
+# Flag that causes arctic to convert byte columns to unicode. This is useful if you are moving from py2 to py3
+# and you want str in py2 to be converted to str in py3 and not bytes.
+# -------------------------------
+FORCE_BYTES_TO_UNICODE = bool(os.environ.get('FORCE_BYTES_TO_UNICODE'))

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -9,6 +9,7 @@ from arctic._util import NP_OBJECT_DTYPE
 from arctic.serialization.numpy_records import SeriesSerializer, DataFrameSerializer
 from ._ndarray_store import NdarrayStore
 from .._compression import compress, decompress
+from .._config import FORCE_BYTES_TO_UNICODE
 from ..date._util import to_pandas_closed_closed
 from ..exceptions import ArcticException
 
@@ -197,7 +198,7 @@ class PandasDataFrameStore(PandasStore):
 
     def read(self, arctic_lib, version, symbol, **kwargs):
         item = super(PandasDataFrameStore, self).read(arctic_lib, version, symbol, **kwargs)
-        return self.SERIALIZER.deserialize(item)
+        return self.SERIALIZER.deserialize(item, force_bytes_to_unicode=FORCE_BYTES_TO_UNICODE)
 
     def read_options(self):
         return super(PandasDataFrameStore, self).read_options()


### PR DESCRIPTION
This adds a config flag which allows users to convert the py2 str
type columns (which are bytes) to be unicode when read back. This
is useful for arctic users migrating from python2 to python3 and
expecting back a py3 string type type which is unicode.