### PR TITLE
Add a way to force bytes columns to unicode via a config flag

### DIFF
--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -213,7 +213,7 @@ class PandasSerializer(object):
     def serialize(self, item, string_max_len=None, forced_dtype=None):
         raise NotImplementedError
 
-    def deserialize(self, item):
+    def deserialize(self, item, force_bytes_to_unicode=False):
         raise NotImplementedError
 
 
@@ -227,7 +227,7 @@ class SeriesSerializer(PandasSerializer):
         column_vals = [s.values]
         return columns, column_vals, None
 
-    def deserialize(self, item):
+    def deserialize(self, item, _force_bytes_to_unicode=False):
         index = self._index_from_records(item)
         name = item.dtype.names[-1]
         return Series.from_array(item[name], index=index, name=name)
@@ -255,7 +255,7 @@ class DataFrameSerializer(PandasSerializer):
         else:
             return columns, column_vals, None
 
-    def deserialize(self, item):
+    def deserialize(self, item, force_bytes_to_unicode=False):
         index = self._index_from_records(item)
         column_fields = [x for x in item.dtype.names if x not in item.dtype.metadata['index']]
         multi_column = item.dtype.metadata.get('multi_column')
@@ -272,6 +272,13 @@ class DataFrameSerializer(PandasSerializer):
 
         if multi_column is not None:
             df.columns = MultiIndex.from_arrays(multi_column["values"], names=multi_column["names"])
+
+        if force_bytes_to_unicode:
+            # This is needed due to 'str' type in py2 when read back in py3 is 'bytes' which breaks the workflow
+            # of people migrating to py3. # https://github.com/manahl/arctic/issues/598
+            for c in df.select_dtypes(object):
+                if type(df[c].iloc[0]) == bytes:
+                    df[c] = df[c].str.decode('utf-8')
 
         return df
 

--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -276,9 +276,20 @@ class DataFrameSerializer(PandasSerializer):
         if force_bytes_to_unicode:
             # This is needed due to 'str' type in py2 when read back in py3 is 'bytes' which breaks the workflow
             # of people migrating to py3. # https://github.com/manahl/arctic/issues/598
+            # This should not be used for a normal flow, and you should instead of writing unicode strings
+            # if you want to work with str in py3.,
+            def convert_pandas_column_to_unicode(col):
+                return col.str.decode('utf-8')
+
             for c in df.select_dtypes(object):
                 if type(df[c].iloc[0]) == bytes:
-                    df[c] = df[c].str.decode('utf-8')
+                    df[c] = convert_pandas_column_to_unicode(df[c])
+
+            if type(df.index[0]) == bytes:
+                df.index = convert_pandas_column_to_unicode(df.index)
+
+            if type(df.columns[0]) == bytes:
+                df.columns = convert_pandas_column_to_unicode(df.columns)
 
         return df
 

--- a/arctic/store/_pandas_ndarray_store.py
+++ b/arctic/store/_pandas_ndarray_store.py
@@ -197,7 +197,7 @@ class PandasDataFrameStore(PandasStore):
 
     def read(self, arctic_lib, version, symbol, **kwargs):
         item = super(PandasDataFrameStore, self).read(arctic_lib, version, symbol, **kwargs)
-        return self.SERIALIZER.deserialize(item)
+        return self.SERIALIZER.deserialize(item, force_bytes_to_unicode=kwargs.get('force_bytes_to_unicode', False))
 
     def read_options(self):
         return super(PandasDataFrameStore, self).read_options()

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1017,7 +1017,7 @@ def test_mutable_df(library):
     assert read_s.data.__array__().flags['WRITEABLE']
 
 
-def test_forced_encodings_with_df(library):
+def test_forced_encodings_with_df_mixed_types(library):
     sample_data = {'str_col': ['a', 'b'], u'unicode_col': [u'a', u'b'], 'int_col': [1, 2]}
     # This is for testing py2 bytes vs unicode serialization issues. Ignoring Py3 for now.
     if six.PY3:
@@ -1044,7 +1044,6 @@ def test_forced_encodings_with_df(library):
     library.write('dummy', df)
 
     # ===================READ BACK WITHOUT FORCED ENCODING===================
-    print('Reading without setting force_byte_to_unicode param')
     df_normal = library.read('dummy').data
     assert type(df_normal['str_col'][0]) == bytes
     assert type(df_normal['unicode_col'][0]) == unicode
@@ -1053,10 +1052,43 @@ def test_forced_encodings_with_df(library):
     assert all([type(x) == unicode for x in df_normal.index])
 
     # ===================READ BACK WITH FORCED ENCODING===================
-    print('Reading without setting force_byte_to_unicode param')
     df_forced_unicode = library.read('dummy', force_bytes_to_unicode=True).data
     assert type(df_forced_unicode['str_col'][0]) == unicode
     assert type(df_forced_unicode['unicode_col'][0]) == unicode
     # Arctic currently converts all column and index string type names to unicode
+    assert all([type(x) == unicode for x in df_forced_unicode.columns])
+    assert all([type(x) == unicode for x in df_forced_unicode.index])
+
+
+def test_forced_encodings_with_df(library):
+    sample_data = {'str_col': ['a', 'b'], 'unicode_col': [u'a', u'b'], 'int_col': [1, 2]}
+    # This is for testing py2 bytes vs unicode serialization issues. Ignoring Py3 for now.
+    if six.PY3:
+        assert True
+        return
+
+    # ===================BEFORE===================
+    df = pd.DataFrame(sample_data, index=['str_type', 'uni_type'])
+    assert type(df['str_col'][0]) == bytes
+    assert type(df['unicode_col'][0]) == unicode
+    # Check that all column names are stored as as is by pandas
+    assert all([type(x) == bytes for x in df.columns])
+    assert all([type(x) == bytes for x in df.index])
+
+    library.write('dummy', df)
+
+    # ===================READ BACK WITHOUT FORCED ENCODING===================
+    df_normal = library.read('dummy').data
+    assert type(df_normal['str_col'][0]) == bytes
+    assert type(df_normal['unicode_col'][0]) == unicode
+    # Arctic currently converts all column to unicode and will keep index type as is
+    assert all([type(x) == unicode for x in df_normal.columns])
+    assert all([type(x) == bytes for x in df_normal.index])
+
+    # ===================READ BACK WITH FORCED ENCODING===================
+    df_forced_unicode = library.read('dummy', force_bytes_to_unicode=True).data
+    assert type(df_forced_unicode['str_col'][0]) == unicode
+    assert type(df_forced_unicode['unicode_col'][0]) == unicode
+    # Should force everything to be unicode now.
     assert all([type(x) == unicode for x in df_forced_unicode.columns])
     assert all([type(x) == unicode for x in df_forced_unicode.index])

--- a/tests/integration/store/test_pandas_store.py
+++ b/tests/integration/store/test_pandas_store.py
@@ -1,4 +1,5 @@
 import itertools
+import six
 import string
 from datetime import datetime as dt, timedelta as dtd
 
@@ -1014,3 +1015,48 @@ def test_mutable_df(library):
     library.write('pandas', s)
     read_s = library.read('pandas')
     assert read_s.data.__array__().flags['WRITEABLE']
+
+
+def test_forced_encodings_with_df(library):
+    sample_data = {'str_col': ['a', 'b'], u'unicode_col': [u'a', u'b'], 'int_col': [1, 2]}
+    # This is for testing py2 bytes vs unicode serialization issues. Ignoring Py3 for now.
+    if six.PY3:
+        assert True
+        return
+
+    # ===================BEFORE===================
+    df = pd.DataFrame(sample_data, index=['str_type', u'uni_type'])
+    assert type(df['str_col'][0]) == bytes
+    assert type(df['unicode_col'][0]) == unicode
+    # Check that all column names are stored as as is by pandas
+    for col in df.columns:
+        if bytes(col) == 'unicode_col':
+            assert type(col) == unicode
+        else:
+            assert type(col) == bytes
+    # Check index types are preserved.
+    for index_val in df.index:
+        if bytes(index_val) == 'uni_type':
+            assert type(index_val) == unicode
+        else:
+            assert type(index_val) == bytes
+
+    library.write('dummy', df)
+
+    # ===================READ BACK WITHOUT FORCED ENCODING===================
+    print('Reading without setting force_byte_to_unicode param')
+    df_normal = library.read('dummy').data
+    assert type(df_normal['str_col'][0]) == bytes
+    assert type(df_normal['unicode_col'][0]) == unicode
+    # Arctic currently converts all column and index string type names to unicode
+    assert all([type(x) == unicode for x in df_normal.columns])
+    assert all([type(x) == unicode for x in df_normal.index])
+
+    # ===================READ BACK WITH FORCED ENCODING===================
+    print('Reading without setting force_byte_to_unicode param')
+    df_forced_unicode = library.read('dummy', force_bytes_to_unicode=True).data
+    assert type(df_forced_unicode['str_col'][0]) == unicode
+    assert type(df_forced_unicode['unicode_col'][0]) == unicode
+    # Arctic currently converts all column and index string type names to unicode
+    assert all([type(x) == unicode for x in df_forced_unicode.columns])
+    assert all([type(x) == unicode for x in df_forced_unicode.index])


### PR DESCRIPTION
This adds a config flag which allows users to convert the py2 str
type columns (which are bytes) to be unicode when read back. This
is useful for arctic users migrating from python2 to python3 and
expecting back a py3 string type type which is unicode.