### PR TITLE
Do not use bytes when loading back pickled objects

### DIFF
--- a/arctic/store/_pickle_store.py
+++ b/arctic/store/_pickle_store.py
@@ -61,13 +61,14 @@ class PickleStore(object):
                 return pickle_compat_load(io.BytesIO(data))
             else:
                 try:
-                    return pickle_compat_load(io.BytesIO(data), encoding='bytes')
+                    # The default encoding is ascii.
+                    return pickle_compat_load(io.BytesIO(data))
                 except UnicodeDecodeError as ue:
-                    logger.error("Could not load Pickled object in PY3 with bytes encoding: %s" % ue)
-                # Using encoding='latin1' is required for unpickling NumPy arrays and instances of datetime, date and
-                # time pickled by Python 2: https://docs.python.org/3/library/pickle.html#pickle.load
-                encoding = kwargs.get('encoding', 'latin_1')  # Check if someone has manually specified encoding.
-                return pickle_compat_load(io.BytesIO(data), encoding=encoding)
+                    # Using encoding='latin1' is required for unpickling NumPy arrays and instances of datetime, date
+                    # and time pickled by Python 2: https://docs.python.org/3/library/pickle.html#pickle.load
+                    logger.info("Could not Unpickle with ascii, Using latin1.")
+                    encoding = kwargs.get('encoding', 'latin_1')  # Check if someone has manually specified encoding.
+                    return pickle_compat_load(io.BytesIO(data), encoding=encoding)
         return version['data']
 
     @staticmethod


### PR DESCRIPTION
This causes an issue with unicode strings in py2. Instead I am using
something similar to:

https://github.com/pandas-dev/pandas/blob/master/pandas/io/pickle.py#L157

where the default is the better option rather than forcing it to use
bytes.