### PR TITLE
Add global settings for caching list_libraries

### DIFF
--- a/arctic/_cache.py
+++ b/arctic/_cache.py
@@ -8,6 +8,11 @@ logger = logging.getLogger(__name__)
 CACHE_COLL = 'cache'
 CACHE_DB = 'meta_db'
 CACHE_SETTINGS = 'cache_settings'
+"""
+Sample cache_settings collection entry:
+meta_db.cache_settings.insertOne({"enabled": true, "cache_expiry": 600})
+meta_db.cache_settings.find(): { "_id" : ObjectId("5cd5388b9fddfbe6e968f11b"), "enabled" : false, "cache_expiry" : 600 }
+"""
 DEFAULT_CACHE_EXPIRY = 3600
 
 

--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -95,13 +95,6 @@ ARCTIC_ASYNC_NWORKERS = os.environ.get('ARCTIC_ASYNC_NWORKERS', 4)
 
 
 # -------------------------------
-# Flag used for indicating caching levels. For now just for list_libraries.
-# -------------------------------
-ENABLE_CACHE = not bool(os.environ.get('DISABLE_CACHE'))
-CACHE_COLL = 'cache'
-CACHE_DB = 'meta_db'
-
-# -------------------------------
 # Flag used to convert byte column/index/column names to unicode when read back.
 # -------------------------------
 FORCE_BYTES_TO_UNICODE = bool(os.environ.get('FORCE_BYTES_TO_UNICODE'))

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -315,3 +315,29 @@ def test_deleting_library_removes_it_from_cache(arctic):
     arctic.delete_library('test1')
 
     assert arctic._list_libraries_cached() == arctic._list_libraries() == arctic.list_libraries() == ['test2']
+
+
+def test_disable_cache_by_settings(arctic):
+    lib = 'test1'
+    arctic.initialize_library(lib)
+
+    # Should be enabled by default
+    assert arctic._list_libraries_cached() == arctic._list_libraries()
+
+    arctic._cache.set_caching_state(enabled=False)
+
+    # Should not return cached results now.
+    with patch('arctic.arctic.Arctic._list_libraries', return_value=[lib]) as uncached_list_libraries:
+        with patch('arctic.arctic.Arctic._list_libraries_cached', return_value=[lib]) as cached_list_libraries:
+            arctic.list_libraries()
+            uncached_list_libraries.assert_called()
+            cached_list_libraries.assert_not_called()
+
+    arctic._cache.set_caching_state(enabled=True)
+
+    # Should used cached data again.
+    with patch('arctic.arctic.Arctic._list_libraries', return_value=[lib]) as uncached_list_libraries_e:
+        with patch('arctic.arctic.Arctic._list_libraries_cached', return_value=[lib]) as cached_list_libraries_e:
+            arctic.list_libraries()
+            uncached_list_libraries_e.assert_not_called()
+            cached_list_libraries_e.assert_called()

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -19,6 +19,7 @@ from arctic._cache import Cache
 def test_arctic_lazy_init():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True) as mc, \
         patch('arctic.arctic.mongo_retry', side_effect=lambda x: x, autospec=True), \
+        patch('arctic._cache.Cache._is_not_expired', return_value=True), \
         patch('arctic.arctic.get_auth', autospec=True) as ga:
             store = Arctic('cluster')
             assert not mc.called
@@ -30,6 +31,7 @@ def test_arctic_lazy_init():
 def test_arctic_lazy_init_ssl_true():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True) as mc, \
             patch('arctic.arctic.mongo_retry', side_effect=lambda x: x, autospec=True), \
+            patch('arctic._cache.Cache._is_not_expired', return_value=True), \
             patch('arctic.arctic.get_auth', autospec=True) as ga:
         store = Arctic('cluster', ssl=True)
         assert not mc.called
@@ -48,6 +50,7 @@ def test_arctic_lazy_init_ssl_true():
 def test_connection_passed_warning_raised():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True), \
          patch('arctic.arctic.mongo_retry', side_effect=lambda x: x, autospec=True), \
+         patch('arctic._cache.Cache._is_not_expired', return_value=True), \
          patch('arctic.arctic.get_auth', autospec=True), \
          patch('arctic.arctic.logger') as lg:
         magic_mock = MagicMock(nodes={("host", "port")})
@@ -62,7 +65,8 @@ def test_connection_passed_warning_raised():
 def test_arctic_auth():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True), \
         patch('arctic.arctic.mongo_retry', autospec=True), \
-        patch('arctic.arctic.get_auth', autospec=True) as ga:
+         patch('arctic._cache.Cache._is_not_expired', return_value=True), \
+         patch('arctic.arctic.get_auth', autospec=True) as ga:
             ga.return_value = Credential('db', 'admin_user', 'admin_pass')
             store = Arctic('cluster')
             # do something to trigger lazy arctic init
@@ -86,7 +90,8 @@ def test_arctic_auth():
 def test_arctic_auth_custom_app_name():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True), \
         patch('arctic.arctic.mongo_retry', autospec=True), \
-        patch('arctic.arctic.get_auth', autospec=True) as ga:
+         patch('arctic._cache.Cache._is_not_expired', return_value=True), \
+         patch('arctic.arctic.get_auth', autospec=True) as ga:
             ga.return_value = Credential('db', 'admin_user', 'admin_pass')
             store = Arctic('cluster', app_name=sentinel.app_name)
             # do something to trigger lazy arctic init
@@ -108,7 +113,8 @@ def test_arctic_auth_custom_app_name():
 def test_arctic_connect_hostname():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True) as mc, \
          patch('arctic.arctic.mongo_retry', autospec=True) as ar, \
-         patch('arctic.arctic.get_mongodb_uri', autospec=True) as gmu:
+            patch('arctic._cache.Cache._is_not_expired', return_value=True), \
+            patch('arctic.arctic.get_mongodb_uri', autospec=True) as gmu:
                 store = Arctic('hostname', socketTimeoutMS=sentinel.socket_timeout,
                                          connectTimeoutMS=sentinel.connect_timeout,
                                          serverSelectionTimeoutMS=sentinel.select_timeout)
@@ -124,6 +130,7 @@ def test_arctic_connect_with_environment_name():
     with patch('pymongo.MongoClient', return_value=MagicMock(), autospec=True) as mc, \
          patch('arctic.arctic.mongo_retry', autospec=True) as ar, \
          patch('arctic.arctic.get_auth', autospec=True), \
+         patch('arctic._cache.Cache._is_not_expired', return_value=True), \
          patch('arctic.arctic.get_mongodb_uri') as gmfe:
             store = Arctic('live', socketTimeoutMS=sentinel.socket_timeout,
                                  connectTimeoutMS=sentinel.connect_timeout,
@@ -453,7 +460,8 @@ def test__conn_auth_issue():
 
 def test_reset():
     c = MagicMock()
-    with patch('pymongo.MongoClient', return_value=c, autospec=True) as mc:
+    with patch('pymongo.MongoClient', return_value=c, autospec=True) as mc, \
+            patch('arctic._cache.Cache._is_not_expired', return_value=True):
                 store = Arctic('hostname')
                 # do something to trigger lazy arctic init
                 store.list_libraries()


### PR DESCRIPTION
This allows us to enable and disable the cache on the fly for list_libraries.
Also allows us to change the expiry period for returning the results.

If user does not have write permissions to meta_db, it will use the slow path. To fix this, you can give permissions using:

db.getSiblingDB('admin').grantRolesToUser("research", [{role: "readWrite", db: "meta_db"}])