### PR TITLE
Fix #777: Handle zero columns when converting to unicode

### DIFF
--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -301,8 +301,8 @@ class DataFrameSerializer(PandasSerializer):
                 if type(df.index[0]) == bytes:
                     df.index = df.index.astype('unicode')
 
-            if type(df.columns[0]) == bytes:
-                df.columns = df.index.astype('unicode')
+            if not df.columns.empty and type(df.columns[0]) == bytes:
+                df.columns = df.columns.astype('unicode')
 
         return df
 


### PR DESCRIPTION
Currently it will break for empty columns due to the missing check.