### PR TITLE
Just specify markdown in setup.py instead of manually converting

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,15 +23,8 @@ from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
 
-# Convert Markdown to RST for PyPI
-# http://stackoverflow.com/a/26737672
-try:
-    import pypandoc
-    long_description = pypandoc.convert_file('README.md', 'rst', format='markdown_github')
-    changelog = pypandoc.convert_file('CHANGES.md', 'rst', format='markdown_github')
-except (IOError, ImportError, OSError):
-    long_description = open('README.md').read()
-    changelog = open('CHANGES.md').read()
+long_description = open('README.md').read()
+changelog = open('CHANGES.md').read()
 
 
 class PyTest(TestCommand):
@@ -74,6 +67,7 @@ setup(
     url="https://github.com/manahl/arctic",
     packages=find_packages(exclude=['tests', 'tests.*', 'benchmarks']),
     long_description='\n'.join((long_description, changelog)),
+    long_description_content_type="text/markdown",
     cmdclass={'test': PyTest},
     setup_requires=["six",
                     "numpy",


### PR DESCRIPTION
Don't think we need to convert it ourselves with this option as given here; https://packaging.python.org/guides/making-a-pypi-friendly-readme/