### PR TITLE
Update info log message in exception handler in chunkstore

### DIFF
--- a/arctic/serialization/numpy_arrays.py
+++ b/arctic/serialization/numpy_arrays.py
@@ -120,7 +120,7 @@ class FrameConverter(object):
             except Exception as e:
                 typ = infer_dtype(df[c], skipna=False)
                 msg = "Column '{}' type is {}".format(str(c), typ)
-                logging.info(msg)
+                logging.warning(msg)
                 raise e
 
         arrays = compress_array(arrays)


### PR DESCRIPTION
Not sure why, but for some reason this log line was an info. Hit an error that triggered this path and it was extremely hard to track down the issue until I changed this line to a warning (it gives the column name, which is critical). 