### PR TITLE
RFC: Admit invalid bson keys in PickleStore

### DIFF
--- a/arctic/store/version_store.py
+++ b/arctic/store/version_store.py
@@ -526,7 +526,7 @@ class VersionStore(object):
             # upon intermittent Mongo errors
             # If, however, we get a DuplicateKeyError, suppress it and raise OperationFailure, so that the method-scoped
             # mongo_retry re-tries and creates a new version, to overcome the issue.
-            mongo_retry(self._versions.insert_one)(version)
+            mongo_retry(self._versions.insert)(version, check_keys=False)
         except DuplicateKeyError as err:
             logger.exception(err)
             raise OperationFailure("A version with the same _id exists, force a clean retry")

--- a/tests/integration/store/test_pickle_store.py
+++ b/tests/integration/store/test_pickle_store.py
@@ -15,6 +15,13 @@ def test_save_read_bson(library):
     assert blob == saved_blob
 
 
+def test_save_read_bson_with_dots(library):
+    """ Check we can write dicts with keys like 'a.b' """
+    blob = {'foo.bar': {'baz': 1}}
+    library.write('BLOB', blob)
+    saved_blob = library.read('BLOB').data
+    assert blob == saved_blob
+
 '''
 Run test at your own discretion. Takes > 60 secs
 def test_save_read_MASSIVE(library):


### PR DESCRIPTION
When saving BSON encodable objects to the `PickleStore`, mongo will
raise an `InvalidName` if any of the fields contain "." or "$". Since we
don't actually need to query these fields (afaik), we can relax this constraint.