### PR TITLE
Fix tests broken due to https://github.com/pytest-dev/pytest/issues/5412

### DIFF
--- a/tests/integration/chunkstore/test_chunkstore.py
+++ b/tests/integration/chunkstore/test_chunkstore.py
@@ -664,19 +664,19 @@ def test_read_chunk_range(chunkstore_lib):
 def test_read_data_doesnt_exist(chunkstore_lib):
     with pytest.raises(NoDataFoundException) as e:
         chunkstore_lib.read('some_data')
-    assert('No data found' in str(e))
+    assert('No data found' in str(e.value))
 
 
 def test_invalid_type(chunkstore_lib):
     with pytest.raises(Exception) as e:
         chunkstore_lib.write('some_data', str("Cannot write a string"), 'D')
-    assert('Can only chunk DataFrames' in str(e))
+    assert('Can only chunk DataFrames' in str(e.value))
 
 
 def test_append_no_data(chunkstore_lib):
     with pytest.raises(NoDataFoundException) as e:
         chunkstore_lib.append('some_data', DataFrame())
-    assert('Symbol does not exist.' in str(e))
+    assert('Symbol does not exist.' in str(e.value))
 
 
 def test_append_upsert(chunkstore_lib):
@@ -849,11 +849,11 @@ def test_rename(chunkstore_lib):
 
     with pytest.raises(Exception) as e:
         chunkstore_lib.rename('new_name', 'new_name')
-    assert('already exists' in str(e))
+    assert('already exists' in str(e.value))
 
     with pytest.raises(NoDataFoundException) as e:
         chunkstore_lib.rename('doesnt_exist', 'temp')
-    assert('No data found for doesnt_exist' in str(e))
+    assert('No data found for doesnt_exist' in str(e.value))
 
     assert('test' not in chunkstore_lib.list_symbols())
 
@@ -1012,7 +1012,7 @@ def test_unnamed_colums(chunkstore_lib):
                    )
     with pytest.raises(Exception) as e:
         chunkstore_lib.write('test_df', df, chunk_size='D')
-    assert('must be named' in str(e))
+    assert('must be named' in str(e.value))
 
     df = DataFrame(data={None: [1, 2, 3]},
                    index=MultiIndex.from_tuples([(dt(2016, 1, 1), 1),
@@ -1022,7 +1022,7 @@ def test_unnamed_colums(chunkstore_lib):
                    )
     with pytest.raises(Exception) as e:
         chunkstore_lib.write('test_df', df, chunk_size='D')
-    assert('must be named' in str(e))
+    assert('must be named' in str(e.value))
 
 
 def test_quarterly_data(chunkstore_lib):

--- a/tests/integration/test_arctic.py
+++ b/tests/integration/test_arctic.py
@@ -191,7 +191,7 @@ def test_lib_rename(arctic):
     assert(l.read('test_data').data == 'abc')
     with pytest.raises(LibraryNotFoundException) as e:
         l = arctic['test']
-    assert('Library test' in str(e))
+    assert('Library test' in str(e.value))
     assert('test' not in arctic.list_libraries())
 
 
@@ -202,7 +202,7 @@ def test_lib_rename_namespace(arctic):
 
     with pytest.raises(ValueError) as e:
         arctic.rename_library('namespace.test', 'new_namespace.test')
-    assert('Collection can only be renamed in the same database' in str(e))
+    assert('Collection can only be renamed in the same database' in str(e.value))
 
     arctic.rename_library('namespace.test', 'namespace.newlib')
     l = arctic['namespace.newlib']
@@ -210,7 +210,7 @@ def test_lib_rename_namespace(arctic):
 
     with pytest.raises(LibraryNotFoundException) as e:
         l = arctic['namespace.test']
-    assert('Library namespace.test' in str(e))
+    assert('Library namespace.test' in str(e.value))
     assert('namespace.test' not in arctic.list_libraries())
 
 

--- a/tests/integration/test_compress_integration.py
+++ b/tests/integration/test_compress_integration.py
@@ -65,10 +65,10 @@ def test_exceptions():
     data = data[0:16]
     with pytest.raises(Exception) as e:
         c.decompress(data)
-    assert("decompressor wrote" in str(e).lower() or "corrupt input at" in str(e).lower() or "decompression failed: corrupt input" in str(e).lower())
+    assert("decompressor wrote" in str(e.value).lower() or "corrupt input at" in str(e.value).lower() or "decompression failed: corrupt input" in str(e.value).lower())
 
     data = c.compress(b'1010101010100000000000000000000000000000000000000000000000000000000011111111111111111111111111111')
     data = [data[0:16] for x in (1, 2, 3)]
     with pytest.raises(Exception) as e:
         c.decompress_array(data)
-    assert ("decompressor wrote" in str(e).lower() or "corrupt input at" in str(e).lower() or "decompression failed: corrupt input" in str(e).lower())
+    assert ("decompressor wrote" in str(e.value).lower() or "corrupt input at" in str(e.value).lower() or "decompression failed: corrupt input" in str(e.value).lower())

--- a/tests/integration/tickstore/test_toplevel.py
+++ b/tests/integration/tickstore/test_toplevel.py
@@ -45,7 +45,7 @@ def test_should_raise_exceptions_if_no_libraries_are_found_in_the_date_range_whe
                                            'library_name': 'FEED_2010.LEVEL1'})
     with pytest.raises(NoDataFoundException) as e:
         toplevel_tickstore.read('blah', DateRange(start=dt(2012, 1, 1), end=dt(2012, 3, 1)))
-    assert "No underlying libraries exist for the given date range" in str(e)
+    assert "No underlying libraries exist for the given date range" in str(e.value)
 
 
 def test_should_return_data_when_date_range_falls_in_a_single_underlying_library(toplevel_tickstore, arctic):
@@ -118,7 +118,7 @@ def test_should_raise_exception_if_library_does_not_exist(toplevel_tickstore):
     with pytest.raises(LibraryNotFoundException) as e:
         toplevel_tickstore.add(DateRange(start=dt(2010, 1, 1), end=dt(2010, 12, 31, 23, 59, 59, 999000)), 'FEED_2010.LEVEL1')
         assert toplevel_tickstore._collection.find_one({'library_name': 'FEED_2010.LEVEL1'})
-    assert "Library FEED_2010.LEVEL1 was not correctly initialized" in str(e)
+    assert "Library FEED_2010.LEVEL1 was not correctly initialized" in str(e.value)
 
 
 def test_should_raise_exception_if_date_range_for_library_overlaps_with_existing_libraries(toplevel_tickstore, arctic):
@@ -127,7 +127,7 @@ def test_should_raise_exception_if_date_range_for_library_overlaps_with_existing
     with pytest.raises(OverlappingDataException) as e:
         toplevel_tickstore.add(DateRange(start=dt(2010, 6, 1), end=dt(2010, 12, 31, 23, 59, 59, 999000)), 'FEED_2010a.LEVEL1')
         assert toplevel_tickstore._collection.find_one({'library_name': 'FEED_2010.LEVEL1'})
-    assert "There are libraries that overlap with the date range:" in str(e)
+    assert "There are libraries that overlap with the date range:" in str(e.value)
 
 
 def test_should_successfully_do_a_roundtrip_write_and_read_spanning_multiple_underlying_libraries(toplevel_tickstore, arctic):

--- a/tests/integration/tickstore/test_ts_read.py
+++ b/tests/integration/tickstore/test_ts_read.py
@@ -701,4 +701,4 @@ def test_objects_fail(tickstore_lib):
 
     with pytest.raises(Exception) as e:
         tickstore_lib.write('test', df)
-    assert('Casting object column to string failed' in str(e))
+    assert('Casting object column to string failed' in str(e.value))

--- a/tests/unit/chunkstore/test_date_chunker.py
+++ b/tests/unit/chunkstore/test_date_chunker.py
@@ -79,12 +79,12 @@ def test_to_chunks_exceptions():
 
     with pytest.raises(Exception) as e:
         six.next(c.to_chunks(df, 'D'))
-    assert('datetime indexed' in str(e))
+    assert('datetime indexed' in str(e.value))
 
     df.columns = ['date']
     with pytest.raises(Exception) as e:
         six.next(c.to_chunks(df, 'ZSDFG'))
-    assert('Unknown freqstr' in str(e) or 'Invalid frequency' in str(e))
+    assert('Unknown freqstr' in str(e.value) or 'Invalid frequency' in str(e.value))
 
 
 def test_exclude():

--- a/tests/unit/serialization/test_numpy_arrays.py
+++ b/tests/unit/serialization/test_numpy_arrays.py
@@ -91,7 +91,7 @@ def test_multi_column_fail():
 
     with pytest.raises(Exception) as e:
         n.deserialize(a, columns=['A', 'B'])
-    assert('Duplicate' in str(e))
+    assert('Duplicate' in str(e.value))
 
 
 def test_dataframe_writable_after_objify():

--- a/tests/unit/store/test_pickle_store.py
+++ b/tests/unit/store/test_pickle_store.py
@@ -171,4 +171,4 @@ def test_pickle_store_future_version():
     ps = PickleStore()
     with pytest.raises(UnsupportedPickleStoreVersion) as e:
         ps.read(arctic_lib, version, sentinel.symbol)
-    assert('unsupported version of pickle store' in str(e))
+    assert('unsupported version of pickle store' in str(e.value))

--- a/tests/unit/store/test_version_store.py
+++ b/tests/unit/store/test_version_store.py
@@ -245,7 +245,7 @@ def test_read_reports_random_errors():
     with pytest.raises(Exception) as e:
         with patch('arctic.store.version_store.log_exception') as le:
             VersionStore.read(self, sentinel.symbol, sentinel.as_of, sentinel.from_version)
-    assert 'bad' in str(e)
+    assert 'bad' in str(e.value)
     assert le.call_count == 1
 
 

--- a/tests/unit/test_arctic.py
+++ b/tests/unit/test_arctic.py
@@ -182,7 +182,7 @@ def test_register_library_type():
 
     with pytest.raises(ArcticException) as e:
         register_library_type("new_dummy_type", DummyType)
-    assert "ArcticException: Library new_dummy_type already registered" in str(e)
+    assert "Library new_dummy_type already registered" in str(e.value)
 
 
 def test_set_quota():
@@ -301,7 +301,7 @@ def test_check_quota_exceeded():
                                                                              }))
     with pytest.raises(QuotaExceededException) as e:
         ArcticLibraryBinding.check_quota(self)
-    assert "Quota Exceeded: arctic_db.lib 1.000 / 1 GB used" in str(e)
+    assert "Quota Exceeded: arctic_db.lib 1.000 / 1 GB used" in str(e.value)
 
 
 def test_initialize_library():
@@ -336,7 +336,7 @@ def test_initialize_library_too_many_ns():
     assert self._conn.__getitem__.call_args_list == [call(sentinel.db_name),
                                                      call(sentinel.db_name)]
     assert lib_type.initialize_library.call_count == 0
-    assert 'Too many namespaces 5001, not creating: sentinel.lib_name' in str(e)
+    assert 'Too many namespaces 5001, not creating: sentinel.lib_name' in str(e.value)
 
 
 def test_initialize_library_with_list_coll_names():
@@ -391,7 +391,7 @@ def test_get_library_not_initialized():
          patch('arctic.arctic.ArcticLibraryBinding', autospec=True) as ML:
         ML.return_value.get_library_type.return_value = None
         Arctic.get_library(self, sentinel.lib_name)
-    assert "Library %s was not correctly initialized in %s." % (sentinel.lib_name, self) in str(e)
+    assert "Library %s was not correctly initialized in %s." % (sentinel.lib_name, self) in str(e.value)
 
 
 def test_get_library_auth_issue():
@@ -401,7 +401,7 @@ def test_get_library_auth_issue():
          patch('arctic.arctic.ArcticLibraryBinding', autospec=True) as ML:
         ML.return_value.get_library_type.side_effect = OperationFailure('database error: not authorized for query on arctic_marketdata.index.ARCTIC')
         Arctic.get_library(self, sentinel.lib_name)
-    assert "Library %s was not correctly initialized in %s." % (sentinel.lib_name, self) in str(e)
+    assert "Library %s was not correctly initialized in %s." % (sentinel.lib_name, self) in str(e.value)
 
 
 def test_get_library_not_registered():
@@ -413,7 +413,7 @@ def test_get_library_not_registered():
         Arctic.get_library(self, sentinel.lib_name)
     assert ("Couldn't load LibraryType '%s' for '%s' (has the class been registered?)" %
             (sentinel.lib_type, sentinel.lib_name)
-            )in str(e)
+            )in str(e.value)
 
 
 def test_mongo_host_get_set():

--- a/tests/unit/test_decorators_unit.py
+++ b/tests/unit/test_decorators_unit.py
@@ -100,7 +100,7 @@ def test_all_other_exceptions_logged():
         foo = mongo_retry(foo)
         with pytest.raises(Exception) as e:
             foo()
-    assert "Unexpected Error" in str(e)
+    assert "Unexpected Error" in str(e.value)
     assert le.call_count == 1
     assert le.call_args[0][0] == "foo"
 
@@ -112,7 +112,7 @@ def test_other_exceptions_not_logged_outside_of_arctic():
             raise Exception("Unexpected Error")
         with pytest.raises(Exception) as e:
             foo()
-    assert "Unexpected Error" in str(e)
+    assert "Unexpected Error" in str(e.value)
     assert le.call_count == 0
 
 
@@ -125,7 +125,7 @@ def test_auth_failure_no_retry():
             raise error
         with pytest.raises(OperationFailure) as e:
             foo()
-    assert 'OperationFailure: unauthorized for db:arctic_jblackburn' in str(e)
+    assert 'OperationFailure: unauthorized for db:arctic_jblackburn' in str(e.value)
     assert le.call_count == 1
 
 
@@ -137,7 +137,7 @@ def test_duplicate_key_failure_no_retry():
             raise error
         with pytest.raises(OperationFailure) as e:
             foo()
-    assert 'duplicate key' in str(e)
+    assert 'duplicate key' in str(e.value)
     assert le.call_count == 1
 
 
@@ -149,7 +149,7 @@ def test_ServerSelectionTimeoutError_no_retry():
             raise error
         with pytest.raises(ServerSelectionTimeoutError) as e:
             foo()
-    assert 'some error' in str(e)
+    assert 'some error' in str(e.value)
     assert le.call_count == 1
 
 

--- a/tests/unit/tickstore/test_toplevel.py
+++ b/tests/unit/tickstore/test_toplevel.py
@@ -24,7 +24,7 @@ def test_raise_exception_if_daterange_is_not_provided():
     store = TopLevelTickStore(Mock())
     with pytest.raises(Exception) as e:
         store._get_library_metadata(None)
-    assert "A date range must be provided" in str(e)
+    assert "A date range must be provided" in str(e.value)
 
 
 def test_raise_exception_if_date_range_does_not_contain_start_date():
@@ -32,7 +32,7 @@ def test_raise_exception_if_date_range_does_not_contain_start_date():
     dr = DateRange(start=None, end=dt(2011, 1, 1))
     with pytest.raises(Exception) as e:
         store._get_library_metadata(dr)
-    assert "The date range {0} must contain a start and end date".format(dr) in str(e)
+    assert "The date range {0} must contain a start and end date".format(dr) in str(e.value)
 
 
 def test_raise_exception_if_date_range_does_not_contain_end_date():
@@ -40,7 +40,7 @@ def test_raise_exception_if_date_range_does_not_contain_end_date():
     dr = DateRange(start=dt(2011, 1, 1), end=None)
     with pytest.raises(Exception) as e:
         store._get_library_metadata(dr)
-    assert "The date range {0} must contain a start and end date".format(dr) in str(e)
+    assert "The date range {0} must contain a start and end date".format(dr) in str(e.value)
 
 
 def test_raise_exception_if_date_range_does_not_contain_start_and_end_date():
@@ -48,7 +48,7 @@ def test_raise_exception_if_date_range_does_not_contain_start_and_end_date():
     dr = DateRange(start=None, end=None)
     with pytest.raises(Exception) as e:
         store._get_library_metadata(dr)
-    assert "The date range {0} must contain a start and end date".format(dr) in str(e)
+    assert "The date range {0} must contain a start and end date".format(dr) in str(e.value)
 
 
 def test_raise_exception_and_log_an_error_if_an_invalid_library_name_is_added():
@@ -66,7 +66,7 @@ def test_raise_exception_if_date_range_overlaps():
     self._get_library_metadata.return_value = [TickStoreLibrary('lib1', None), ]
     with pytest.raises(OverlappingDataException) as e:
         TopLevelTickStore.add(self, DateRange(start=dt(2010, 1, 1), end=dt(2011, 1, 1, 23, 59, 59, 999000)), "blah")
-    assert "There are libraries that overlap with the date range:" in str(e)
+    assert "There are libraries that overlap with the date range:" in str(e.value)
 
 
 @pytest.mark.parametrize(('start', 'end', 'expected_start', 'expected_end'),
@@ -103,7 +103,7 @@ def test_raise_error_add_library_is_called_with_a_date_range_not_on_day_boundari
         self = create_autospec(TopLevelTickStore, _arctic_lib=MagicMock(), _collection=MagicMock())
         self._get_library_metadata.return_value = []
         TopLevelTickStore.add(self, DateRange(start=start, end=end), "blah")
-    assert "Date range should fall on UTC day boundaries" in str(e)
+    assert "Date range should fall on UTC day boundaries" in str(e.value)
 
 
 @pytest.mark.parametrize(('start', 'end', 'expected_start_index', 'expected_end_index'),
@@ -179,4 +179,4 @@ def test_slice_raises():
     m = TopLevelTickStore(Mock())
     with pytest.raises(UnhandledDtypeException) as e:
         m._slice("abc", 1, 2)
-    assert("Can't persist type" in str(e))
+    assert("Can't persist type" in str(e.value))


### PR DESCRIPTION
This breaks our tests as we use str(e) everywhere and as the above
PR changes the behaviour of str to be the same as repr which is to
print the ExceptionInfo Object, which breaks our tests as we expect str(e) to contain the message