### PR TITLE
Hardcode fwd pointer disabling

### DIFF
--- a/arctic/_config.py
+++ b/arctic/_config.py
@@ -51,16 +51,8 @@ FW_POINTERS_REFS_KEY = 'SEGMENT_SHAS'
 FW_POINTERS_CONFIG_KEY = 'FW_POINTERS_CONFIG'
 
 # This variable has effect only in Hybrid mode, and controls whether forward and legacy pointers are cross-verified
-ARCTIC_FORWARD_POINTERS_RECONCILE = bool(os.environ.get('ARCTIC_FORWARD_POINTERS_RECONCILE'))
-try:
-    # Controls the mode of operation for FW pointers, has effect on any new versions created
-    ARCTIC_FORWARD_POINTERS_CFG = FwPointersCfg[(os.environ.get('ARCTIC_FORWARD_POINTERS_CFG',
-                                                                FwPointersCfg.DISABLED.name).upper())]
-except Exception:
-    logger.exception("Failed to configure forward pointers with configuration {}".format(
-        os.environ.get('ARCTIC_FORWARD_POINTERS_CFG')))
-    ARCTIC_FORWARD_POINTERS_CFG = FwPointersCfg.DISABLED
-
+ARCTIC_FORWARD_POINTERS_RECONCILE = False
+ARCTIC_FORWARD_POINTERS_CFG = FwPointersCfg.DISABLED
 
 # ---------------------------
 # Compression configuration


### PR DESCRIPTION
Explicitly disabling forward pointers and can't be set from env accidentally as it might cause data corruption. Once I finish the revert PR, will completely remove this.