### PR TITLE
Update pandas requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
                       "enum-compat",
                       "futures; python_version == '2.7'",
                       "mockextras",
-                      "pandas",
+                      "pandas <= 0.24.2",
                       "pymongo>=3.6.0",
                       "python-dateutil",
                       "pytz",


### PR DESCRIPTION
Pandas removed the 'compat' argument from pickle_compat.load in 0.25.0. This causes
a failure when reading from versionstore if the pandas version is >= 0.25.0. 0.24.2
is the most recent release where 'compat' is available.

The pandas change: [https://github.com/pandas-dev/pandas/blob/d1accd032b648c9affd6dce1f81feb9c99422483/pandas/compat/pickle_compat.py#L197](https://github.com/pandas-dev/pandas/blob/d1accd032b648c9affd6dce1f81feb9c99422483/pandas/compat/pickle_compat.py#L197)

The incompatible line in arctic: [https://github.com/manahl/arctic/blob/02d0e7daa58fd110a3d39f1d534fdafc2d08918c/arctic/store/_version_store_utils.py#L146](https://github.com/manahl/arctic/blob/02d0e7daa58fd110a3d39f1d534fdafc2d08918c/arctic/store/_version_store_utils.py#L146)

Of course, the real solution is to update the line in arctic to be compatible, but this will prevent others from running into this issue in the mean-time.