### PR TITLE
Pass kwargs to TickStore while initialising lib

### DIFF
--- a/arctic/tickstore/tickstore.py
+++ b/arctic/tickstore/tickstore.py
@@ -100,7 +100,7 @@ class TickStore(object):
 
     @classmethod
     def initialize_library(cls, arctic_lib, **kwargs):
-        TickStore(arctic_lib)._ensure_index()
+        TickStore(arctic_lib, **kwargs)._ensure_index()
 
     @mongo_retry
     def _ensure_index(self):


### PR DESCRIPTION
This way 'chunk_size' is properly configured